### PR TITLE
Remove unused datasets import from tests

### DIFF
--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -19,11 +19,8 @@ import torch
 
 
 # Check availability for skip logic
-try:
-    import datasets
-    _DATASETS_AVAILABLE = True
-except ImportError:
-    _DATASETS_AVAILABLE = False
+import importlib.util
+_DATASETS_AVAILABLE = importlib.util.find_spec("datasets") is not None
 
 from thinkrl.data.datasets import PreferenceDataset, RLHFDataset
 

--- a/tests/test_data/test_processors.py
+++ b/tests/test_data/test_processors.py
@@ -16,17 +16,9 @@ from thinkrl.data.processors import process_audio, process_image
 
 
 # Check actual availability in the module we are testing
-try:
-    from PIL import Image
-    _PIL_AVAILABLE = True
-except ImportError:
-    _PIL_AVAILABLE = False
-
-try:
-    import librosa
-    _AUDIO_AVAILABLE = True
-except ImportError:
-    _AUDIO_AVAILABLE = False
+import importlib.util
+_PIL_AVAILABLE = importlib.util.find_spec("PIL") is not None
+_AUDIO_AVAILABLE = importlib.util.find_spec("librosa") is not None
 
 
 # --- Image Processor Tests ---

--- a/tests/test_utils/test_checkpoint.py
+++ b/tests/test_utils/test_checkpoint.py
@@ -156,9 +156,8 @@ class TestStandaloneFunctions:
 
     def test_save_load_config_yaml(self, temp_dir):
         """Test saving and loading config as YAML."""
-        try:
-            import yaml
-        except ImportError:
+        import importlib.util
+        if importlib.util.find_spec("yaml") is None:
             pytest.skip("PyYAML not installed")
 
         config = {"lr": 0.01, "model": "gpt2"}

--- a/tests/test_utils/test_data.py
+++ b/tests/test_utils/test_data.py
@@ -10,11 +10,8 @@ import pytest
 import torch
 
 
-try:
-    import cupy as cp
-    _CUPY_AVAILABLE = True
-except (ImportError, OSError):
-    _CUPY_AVAILABLE = False
+import importlib.util
+_CUPY_AVAILABLE = importlib.util.find_spec("cupy") is not None
 
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -16,6 +16,7 @@ import logging
 import logging.handlers  # Import handlers for isinstance check
 import shutil
 import tempfile
+import warnings
 from pathlib import Path
 
 import pytest
@@ -45,11 +46,12 @@ def temp_dir():
     try:
         shutil.rmtree(temp_dir_path)
     except PermissionError:
-        print(
-            f"Warning: Could not remove temp directory {temp_dir_path} due to PermissionError."
+        warnings.warn(
+            f"Could not remove temp directory {temp_dir_path} due to PermissionError.",
+            stacklevel=2
         )
     except OSError as e:
-        print(f"Warning: Error removing temp directory {temp_dir_path}: {e}")
+        warnings.warn(f"Error removing temp directory {temp_dir_path}: {e}", stacklevel=2)
 
 
 # ============================================================================

--- a/thinkrl/utils/metrics.py
+++ b/thinkrl/utils/metrics.py
@@ -456,7 +456,7 @@ def compute_statistical_metrics(
 
 def _prepare_array(
     values: torch.Tensor | np.ndarray | list[float] | float
-) -> tuple[np.ndarray | 'cp.ndarray' | None, Any]:
+) -> tuple[np.ndarray | cp.ndarray | None, Any]:
     """
     Convert input to appropriate array type (CuPy for GPU, NumPy for CPU).
 
@@ -502,7 +502,7 @@ def _prepare_array(
 
 
 def _compute_basic_stats(
-    data: np.ndarray | 'cp.ndarray',
+    data: np.ndarray | cp.ndarray,
     xp: Any
 ) -> dict[str, float]:
     """Compute basic statistical measures."""
@@ -537,7 +537,7 @@ def _compute_basic_stats(
 
 
 def _compute_percentiles(
-    data: np.ndarray | 'cp.ndarray',
+    data: np.ndarray | cp.ndarray,
     xp: Any
 ) -> dict[str, float]:
     """Compute percentile statistics efficiently."""
@@ -563,7 +563,7 @@ def _compute_percentiles(
 
 
 def _compute_higher_moments(
-    data: np.ndarray | 'cp.ndarray',
+    data: np.ndarray | cp.ndarray,
     xp: Any
 ) -> dict[str, float]:
     """Compute skewness and kurtosis with appropriate libraries."""
@@ -606,7 +606,7 @@ def _compute_higher_moments(
 
 
 def _compute_moments_manual(
-    data: np.ndarray | 'cp.ndarray',
+    data: np.ndarray | cp.ndarray,
     xp: Any
 ) -> dict[str, float]:
     """Manually compute skewness and kurtosis without scipy."""


### PR DESCRIPTION
- Replace try/except import patterns with importlib.util.find_spec for availability checks (F401 errors)
- Replace print statements with warnings.warn in test fixtures (T201 errors)
- Remove quotes from type annotations in metrics.py (UP037 errors)