### PR TITLE
Remove trailing whitespace from workflow files

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           cd docs
           # turning warnings into errors ensures high quality docs
-          SPHINXOPTS="-W" make html 
+          SPHINXOPTS="-W" make html
 
       - name: Upload Documentation Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Free Disk Space
         run: |
           sudo rm -rf /usr/share/dotnet
@@ -25,12 +25,12 @@ jobs:
           sudo docker system prune -af
           sudo apt-get clean
           df -h
-      
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -44,7 +44,7 @@ jobs:
           pip install pytest>=7.4.0 pytest-cov>=4.1.0 pytest-xdist>=3.3.0 pytest-mock>=3.11.0
           # Install package in editable mode
           pip install -e .
-      
+
       - name: Run tests
         run: |
           pytest tests/ -v \
@@ -56,7 +56,7 @@ jobs:
         env:
           CUDA_VISIBLE_DEVICES: ""
           PYTHONPATH: ${{ github.workspace }}
-      
+
       - name: Upload coverage
         if: matrix.python-version == '3.11' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v4
@@ -75,19 +75,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Free Disk Space
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo apt-get clean
           df -h
-      
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -95,7 +95,7 @@ jobs:
           pip install transformers>=4.35.0 accelerate>=0.24.0
           pip install pytest>=7.4.0 pytest-cov>=4.1.0
           pip install -e .
-      
+
       - name: Run compatibility tests
         run: |
           python -c "import platform; import thinkrl; print(f'ThinkRL {thinkrl.__version__} on {platform.system()}')"
@@ -110,29 +110,29 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Free Disk Space
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo apt-get clean
           df -h
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      
+
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
           pip install build twine wheel
-      
+
       - name: Build package
         run: python -m build
-      
+
       - name: Check package
         run: twine check dist/*
-      
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -44,7 +44,7 @@ jobs:
           source .venv/bin/activate
           # Install thinkrl with dev dependencies
           uv pip install ".[dev]"
-          
+
           # Force install the latest development versions of key libraries
           # This catches breaking changes in dependencies before they hit your users
           uv pip install -U git+https://github.com/huggingface/accelerate.git

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -54,7 +54,7 @@ cd ThinkRL
 
 # 2. Create and activate virtual environment
 python -m venv .venv
-source .venv/bin/activate  
+source .venv/bin/activate
 # On Windows: .venv\Scripts\activate
 
 # 3. Install the complete development environment (includes dev, test, and docs tools)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## 🎉 Latest Updates
 
-- **November 2025**: 
+- **November 2025**:
   - **GPU Acceleration**: Integrated **CuPy** to replace NumPy for metric computations, enabling zero-copy GPU processing and significantly reducing training latency. Added robust CPU fallback for compatibility.
   - **Core Utilities**: Completed implementation and unit testing for `logging`, `checkpoint`, `metrics`, and `data` modules.
 - **July 2025**: ThinkRL will launch with cutting-edge algorithms such as VAPO, DAPO, GRPO, PPO, and REINFORCE, aiming to set new standards in reasoning performance.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,23 +6,22 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'ThinkRL'
-copyright = '2025, Archit Sood'
-author = 'Archit Sood'
-release = '2025'
+project = "ThinkRL"
+copyright = "2025, Archit Sood"
+author = "Archit Sood"
+release = "2025"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = []
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
-
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
-html_static_path = ['_static']
+html_theme = "alabaster"
+html_static_path = ["_static"]

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ def read_readme():
     except FileNotFoundError:
         return __doc__
 
+
 # Read version from __init__.py
 def read_version():
     """Read version from thinkrl/__init__.py."""
@@ -27,13 +28,13 @@ def read_version():
         # Assuming thinkrl/__init__.py exists and contains __version__
         version_file = os.path.join("thinkrl", "__init__.py")
         if os.path.exists(version_file):
-             with open(version_file, encoding="utf-8") as f:
+            with open(version_file, encoding="utf-8") as f:
                 for line in f:
                     if line.startswith("__version__"):
                         return line.split("=")[1].strip().strip('"').strip("'")
         else:
-             # Fallback if thinkrl/__init__.py doesn't exist yet
-             with open("tests/__init__.py", encoding="utf-8") as f:
+            # Fallback if thinkrl/__init__.py doesn't exist yet
+            with open("tests/__init__.py", encoding="utf-8") as f:
                 for line in f:
                     if line.startswith("__version__"):
                         return line.split("=")[1].strip().strip('"').strip("'")
@@ -164,7 +165,7 @@ UTILITIES_REQUIREMENTS = {
         "sentencepiece>=0.1.99",
         "protobuf>=3.20.0,<5.0.0",
     ],
-     "api": [
+    "api": [
         "requests>=2.31.0",
         "aiohttp>=3.8.0",
         "urllib3>=2.0.0",
@@ -258,102 +259,107 @@ CI_REQUIREMENTS = {
 CONVENIENCE_BUNDLES = {
     # State-of-the-art algorithms with GPU support
     # Includes inference for RLAIF generation
-    "sota": list(set(
-        # CORE_REQUIREMENTS + # Core should be installed by default
-        GPU_REQUIREMENTS["cuda"] +
-        FRAMEWORK_REQUIREMENTS["transformers"] +
-        FRAMEWORK_REQUIREMENTS["peft"] +
-        REASONING_REQUIREMENTS["reasoning"] +
-        REASONING_REQUIREMENTS["math"] +
-        INFERENCE_REQUIREMENTS["inference"]
-    )),
-
+    "sota": list(
+        set(
+            # CORE_REQUIREMENTS + # Core should be installed by default
+            GPU_REQUIREMENTS["cuda"]
+            + FRAMEWORK_REQUIREMENTS["transformers"]
+            + FRAMEWORK_REQUIREMENTS["peft"]
+            + REASONING_REQUIREMENTS["reasoning"]
+            + REASONING_REQUIREMENTS["math"]
+            + INFERENCE_REQUIREMENTS["inference"]
+        )
+    ),
     # Distributed training setup
-    "distributed": list(set(
-        # CORE_REQUIREMENTS +
-        GPU_REQUIREMENTS["cuda"] +
-        FRAMEWORK_REQUIREMENTS["deepspeed"] +
-        FRAMEWORK_REQUIREMENTS["fsdp"]
-    )),
-
+    "distributed": list(
+        set(
+            # CORE_REQUIREMENTS +
+            GPU_REQUIREMENTS["cuda"] + FRAMEWORK_REQUIREMENTS["deepspeed"] + FRAMEWORK_REQUIREMENTS["fsdp"]
+        )
+    ),
     # Research setup
-    "research": list(set(
-        # CORE_REQUIREMENTS +
-        GPU_REQUIREMENTS["cuda"] +
-        FRAMEWORK_REQUIREMENTS["transformers"] +
-        FRAMEWORK_REQUIREMENTS["peft"] +
-        REASONING_REQUIREMENTS["reasoning"] +
-        REASONING_REQUIREMENTS["math"] +
-        LOGGING_REQUIREMENTS["wandb"] +
-        EVAL_REQUIREMENTS["eval"] +
-        UTILITIES_REQUIREMENTS["data_processing"]
-    )),
-
+    "research": list(
+        set(
+            # CORE_REQUIREMENTS +
+            GPU_REQUIREMENTS["cuda"]
+            + FRAMEWORK_REQUIREMENTS["transformers"]
+            + FRAMEWORK_REQUIREMENTS["peft"]
+            + REASONING_REQUIREMENTS["reasoning"]
+            + REASONING_REQUIREMENTS["math"]
+            + LOGGING_REQUIREMENTS["wandb"]
+            + EVAL_REQUIREMENTS["eval"]
+            + UTILITIES_REQUIREMENTS["data_processing"]
+        )
+    ),
     # Production setup (example, adjust as needed)
-    "production": list(set(
-        # CORE_REQUIREMENTS +
-        GPU_REQUIREMENTS["cuda"] +
-        FRAMEWORK_REQUIREMENTS["transformers"] +
-        FRAMEWORK_REQUIREMENTS["deepspeed"] +
-        LOGGING_REQUIREMENTS["tensorboard"] +
-        UTILITIES_REQUIREMENTS["api"] +
-        INFERENCE_REQUIREMENTS["inference"]
-    )),
-
+    "production": list(
+        set(
+            # CORE_REQUIREMENTS +
+            GPU_REQUIREMENTS["cuda"]
+            + FRAMEWORK_REQUIREMENTS["transformers"]
+            + FRAMEWORK_REQUIREMENTS["deepspeed"]
+            + LOGGING_REQUIREMENTS["tensorboard"]
+            + UTILITIES_REQUIREMENTS["api"]
+            + INFERENCE_REQUIREMENTS["inference"]
+        )
+    ),
     # Complete development environment - includes almost everything from requirements.txt
-    "complete": list(set(
-        CORE_REQUIREMENTS +
-        GPU_REQUIREMENTS["cuda"] +
-        FRAMEWORK_REQUIREMENTS["transformers"] +
-        FRAMEWORK_REQUIREMENTS["peft"] +
-        FRAMEWORK_REQUIREMENTS["deepspeed"] +
-        MODALITY_REQUIREMENTS["multimodal"] +
-        REASONING_REQUIREMENTS["reasoning"] +
-        REASONING_REQUIREMENTS["math"] +
-        REASONING_REQUIREMENTS["code"] +
-        LOGGING_REQUIREMENTS["wandb"] +
-        LOGGING_REQUIREMENTS["tensorboard"] +
-        LOGGING_REQUIREMENTS["mlflow"] +
-        UTILITIES_REQUIREMENTS["data_processing"] +
-        UTILITIES_REQUIREMENTS["general_utils"] +
-        UTILITIES_REQUIREMENTS["serialization"] +
-        UTILITIES_REQUIREMENTS["api"] +
-        DEV_REQUIREMENTS["dev"] +
-        DEV_REQUIREMENTS["format"] +
-        DEV_REQUIREMENTS["quality"] +
-        EVAL_REQUIREMENTS["eval"] +
-        EVAL_REQUIREMENTS["benchmarks"] +
-        INFERENCE_REQUIREMENTS["inference"] # Added vLLM support
-    )),
-
+    "complete": list(
+        set(
+            CORE_REQUIREMENTS
+            + GPU_REQUIREMENTS["cuda"]
+            + FRAMEWORK_REQUIREMENTS["transformers"]
+            + FRAMEWORK_REQUIREMENTS["peft"]
+            + FRAMEWORK_REQUIREMENTS["deepspeed"]
+            + MODALITY_REQUIREMENTS["multimodal"]
+            + REASONING_REQUIREMENTS["reasoning"]
+            + REASONING_REQUIREMENTS["math"]
+            + REASONING_REQUIREMENTS["code"]
+            + LOGGING_REQUIREMENTS["wandb"]
+            + LOGGING_REQUIREMENTS["tensorboard"]
+            + LOGGING_REQUIREMENTS["mlflow"]
+            + UTILITIES_REQUIREMENTS["data_processing"]
+            + UTILITIES_REQUIREMENTS["general_utils"]
+            + UTILITIES_REQUIREMENTS["serialization"]
+            + UTILITIES_REQUIREMENTS["api"]
+            + DEV_REQUIREMENTS["dev"]
+            + DEV_REQUIREMENTS["format"]
+            + DEV_REQUIREMENTS["quality"]
+            + EVAL_REQUIREMENTS["eval"]
+            + EVAL_REQUIREMENTS["benchmarks"]
+            + INFERENCE_REQUIREMENTS["inference"]  # Added vLLM support
+        )
+    ),
     # 'all' extra - made identical to 'complete' but includes legacy/compat versions
-    "all": list(set(
-        CORE_REQUIREMENTS +
-        GPU_REQUIREMENTS["cuda"] +
-        GPU_REQUIREMENTS["cuda11"] +
-        FRAMEWORK_REQUIREMENTS["transformers"] +
-        FRAMEWORK_REQUIREMENTS["peft"] +
-        FRAMEWORK_REQUIREMENTS["deepspeed"] +
-        FRAMEWORK_REQUIREMENTS["fsdp"] +
-        MODALITY_REQUIREMENTS["multimodal"] +
-        REASONING_REQUIREMENTS["reasoning"] +
-        REASONING_REQUIREMENTS["math"] +
-        REASONING_REQUIREMENTS["code"] +
-        LOGGING_REQUIREMENTS["wandb"] +
-        LOGGING_REQUIREMENTS["tensorboard"] +
-        LOGGING_REQUIREMENTS["mlflow"] +
-        UTILITIES_REQUIREMENTS["data_processing"] +
-        UTILITIES_REQUIREMENTS["general_utils"] +
-        UTILITIES_REQUIREMENTS["serialization"] +
-        UTILITIES_REQUIREMENTS["api"] +
-        DEV_REQUIREMENTS["dev"] +
-        DEV_REQUIREMENTS["format"] +
-        DEV_REQUIREMENTS["quality"] +
-        DEV_REQUIREMENTS["docs"] +
-        EVAL_REQUIREMENTS["eval"] +
-        EVAL_REQUIREMENTS["benchmarks"] +
-        INFERENCE_REQUIREMENTS["inference"]
-    )),
+    "all": list(
+        set(
+            CORE_REQUIREMENTS
+            + GPU_REQUIREMENTS["cuda"]
+            + GPU_REQUIREMENTS["cuda11"]
+            + FRAMEWORK_REQUIREMENTS["transformers"]
+            + FRAMEWORK_REQUIREMENTS["peft"]
+            + FRAMEWORK_REQUIREMENTS["deepspeed"]
+            + FRAMEWORK_REQUIREMENTS["fsdp"]
+            + MODALITY_REQUIREMENTS["multimodal"]
+            + REASONING_REQUIREMENTS["reasoning"]
+            + REASONING_REQUIREMENTS["math"]
+            + REASONING_REQUIREMENTS["code"]
+            + LOGGING_REQUIREMENTS["wandb"]
+            + LOGGING_REQUIREMENTS["tensorboard"]
+            + LOGGING_REQUIREMENTS["mlflow"]
+            + UTILITIES_REQUIREMENTS["data_processing"]
+            + UTILITIES_REQUIREMENTS["general_utils"]
+            + UTILITIES_REQUIREMENTS["serialization"]
+            + UTILITIES_REQUIREMENTS["api"]
+            + DEV_REQUIREMENTS["dev"]
+            + DEV_REQUIREMENTS["format"]
+            + DEV_REQUIREMENTS["quality"]
+            + DEV_REQUIREMENTS["docs"]
+            + EVAL_REQUIREMENTS["eval"]
+            + EVAL_REQUIREMENTS["benchmarks"]
+            + INFERENCE_REQUIREMENTS["inference"]
+        )
+    ),
 }
 
 # Combine all extras
@@ -376,23 +382,18 @@ CONSOLE_SCRIPTS = {
     # Core training commands
     "thinkrl": "thinkrl.scripts.train:main",
     "thinkrl-train": "thinkrl.scripts.train:main",
-
     # Evaluation commands
     "thinkrl-eval": "thinkrl.scripts.evaluate:main",
     "thinkrl-evaluate": "thinkrl.scripts.evaluate:main",
-
     # Reasoning commands
     "thinkrl-cot": "thinkrl.scripts.chain_of_thought:main",
     "thinkrl-tot": "thinkrl.scripts.tree_of_thought:main",
     "thinkrl-reason": "thinkrl.scripts.reasoning:main",
-
     # Specialized training
     "thinkrl-multimodal": "thinkrl.scripts.multimodal_train:main",
     "thinkrl-distributed": "thinkrl.scripts.distributed_train:main",
-
     # RLAIF generation
     "thinkrl-rlaif": "thinkrl.scripts.generate_rlaif_data:main",
-
     # Utilities
     "thinkrl-convert": "thinkrl.scripts.convert:main",
     "thinkrl-benchmark": "thinkrl.scripts.benchmark:main",
@@ -402,39 +403,31 @@ CONSOLE_SCRIPTS = {
 CLASSIFIERS = [
     # Development status
     "Development Status :: 4 - Beta",
-
     # Intended audience
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Education",
-
     # License
     "License :: OSI Approved :: Apache Software License",
-
     # OS support
     "Operating System :: OS Independent",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
-
     # Python versions
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-
     # Topics
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Text Processing :: Linguistic",
-
     # Framework
     "Framework :: Pytest",
-
     # Natural language
     "Natural Language :: English",
-
     # Environment
     "Environment :: Console",
     "Environment :: GPU :: NVIDIA CUDA",
@@ -493,16 +486,13 @@ setup(
     author_email="archit@ellanorai.org",
     maintainer="EllanorAI Team",
     maintainer_email="team@ellanorai.org",
-
     # Package description
     description="Universal RLHF/RLAIF Training Library with state-of-the-art algorithms, reasoning, and multimodal support",
     long_description=read_readme(),
     long_description_content_type="text/markdown",
-
     # URLs and links
     url="https://github.com/Archit03/ThinkRL",
     project_urls=PROJECT_URLS,
-
     # Package discovery
     packages=find_packages(
         exclude=[
@@ -516,7 +506,6 @@ setup(
             "scripts.*",
         ]
     ),
-
     # Include additional files
     include_package_data=True,
     package_data={
@@ -526,29 +515,21 @@ setup(
             "py.typed",
         ],
     },
-
     # Dependencies
     python_requires=">=3.10,<3.13",
     install_requires=CORE_REQUIREMENTS,
     extras_require=EXTRAS_REQUIRE,
-
     # Entry points
     entry_points={
-        "console_scripts": [
-            f"{name}={entry_point}"
-            for name, entry_point in CONSOLE_SCRIPTS.items()
-        ],
+        "console_scripts": [f"{name}={entry_point}" for name, entry_point in CONSOLE_SCRIPTS.items()],
     },
-
     # Package metadata
     classifiers=CLASSIFIERS,
     keywords=KEYWORDS,
     license="Apache-2.0",
-
     # Package options
     zip_safe=False,
     platforms=["any"],
-
     # Additional metadata
     options={
         "bdist_wheel": {

--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -33,9 +33,7 @@ from thinkrl.data.datasets import PreferenceDataset, RLHFDataset
 class MockTokenizer:
     """A mock tokenizer for testing."""
 
-    def __init__(
-        self, padding_side="right", pad_token_id=0, eos_token="<EOS>", eos_token_id=1
-    ):
+    def __init__(self, padding_side="right", pad_token_id=0, eos_token="<EOS>", eos_token_id=1):
         self.padding_side = padding_side
         self.pad_token_id = pad_token_id
         self.eos_token = eos_token
@@ -161,9 +159,7 @@ class TestRLHFDataset:
         )
         assert len(dataset) == 4  # 3 valid, 1 needs stripping
         assert dataset.data[0]["prompt"] == "this is prompt 1."
-        assert (
-            dataset.data[3]["prompt"] == "needs stripping."
-        )  # Stripped and preprocessed
+        assert dataset.data[3]["prompt"] == "needs stripping."  # Stripped and preprocessed
 
     def test_getitem(self, temp_jsonl_file, mock_tokenizer):
         """Test the __getitem__ method for tokenization."""

--- a/tests/test_data/test_loaders.py
+++ b/tests/test_data/test_loaders.py
@@ -129,9 +129,7 @@ def test_dataloader_basic(mock_tokenizer_right):
     """Test basic initialization and iteration of RLHFDataLoader."""
     dataset = SimpleDataset()
 
-    loader = RLHFDataLoader(
-        dataset, mock_tokenizer_right, batch_size=2, shuffle=False, drop_last=False
-    )
+    loader = RLHFDataLoader(dataset, mock_tokenizer_right, batch_size=2, shuffle=False, drop_last=False)
 
     batches = list(loader)
     assert len(batches) == 2  # 3 items / 2 batch_size -> 2 batches

--- a/tests/test_data/test_processors.py
+++ b/tests/test_data/test_processors.py
@@ -129,9 +129,7 @@ class TestProcessAudio:
 
         result = process_audio("test.wav", sr=16000)
 
-        mock_librosa.resample.assert_called_with(
-            "audio_data_44k", orig_sr=44100, target_sr=16000
-        )
+        mock_librosa.resample.assert_called_with("audio_data_44k", orig_sr=44100, target_sr=16000)
         assert result == "audio_data_16k"
 
     @pytest.mark.skipif(not _AUDIO_AVAILABLE, reason="Librosa not installed")
@@ -146,9 +144,7 @@ class TestProcessAudio:
         result = process_audio("test.wav", sr=16000, transform=mock_transform)
 
         # Verify transform call signature matches the implementation
-        mock_transform.assert_called_with(
-            "raw_audio", sampling_rate=16000, return_tensors="pt"
-        )
+        mock_transform.assert_called_with("raw_audio", sampling_rate=16000, return_tensors="pt")
         assert result == "spectrogram"
 
     def test_process_audio_no_libs(self):
@@ -159,10 +155,7 @@ class TestProcessAudio:
 
                 assert result is None
                 mock_logger.warning.assert_called_once()
-                assert (
-                    "librosa/soundfile not installed"
-                    in mock_logger.warning.call_args[0][0]
-                )
+                assert "librosa/soundfile not installed" in mock_logger.warning.call_args[0][0]
 
     @pytest.mark.skipif(not _AUDIO_AVAILABLE, reason="Librosa not installed")
     @patch("thinkrl.data.processors._AUDIO_AVAILABLE", True)

--- a/tests/test_utils/test_checkpoint.py
+++ b/tests/test_utils/test_checkpoint.py
@@ -59,9 +59,7 @@ class TestCheckpointManager:
 
     def test_save_and_cleanup(self, temp_dir, simple_model, simple_optimizer):
         """Test saving checkpoints and automatic cleanup."""
-        manager = CheckpointManager(
-            checkpoint_dir=temp_dir, max_checkpoints=2, metric_name="loss", mode="min"
-        )
+        manager = CheckpointManager(checkpoint_dir=temp_dir, max_checkpoints=2, metric_name="loss", mode="min")
 
         # Save 3 checkpoints
         for i, loss in enumerate([0.5, 0.3, 0.4]):
@@ -87,19 +85,11 @@ class TestCheckpointManager:
 
     def test_load_best(self, temp_dir, simple_model, simple_optimizer):
         """Test loading the best checkpoint."""
-        manager = CheckpointManager(
-            checkpoint_dir=temp_dir, metric_name="acc", mode="max"
-        )
+        manager = CheckpointManager(checkpoint_dir=temp_dir, metric_name="acc", mode="max")
 
-        manager.save_checkpoint(
-            simple_model, epoch=1, metrics={"acc": 0.8}, checkpoint_name="ckpt_1"
-        )
-        manager.save_checkpoint(
-            simple_model, epoch=2, metrics={"acc": 0.9}, checkpoint_name="ckpt_2"
-        )  # Best
-        manager.save_checkpoint(
-            simple_model, epoch=3, metrics={"acc": 0.85}, checkpoint_name="ckpt_3"
-        )
+        manager.save_checkpoint(simple_model, epoch=1, metrics={"acc": 0.8}, checkpoint_name="ckpt_1")
+        manager.save_checkpoint(simple_model, epoch=2, metrics={"acc": 0.9}, checkpoint_name="ckpt_2")  # Best
+        manager.save_checkpoint(simple_model, epoch=3, metrics={"acc": 0.85}, checkpoint_name="ckpt_3")
 
         nn.init.constant_(simple_model.weight, 0.0)
 
@@ -109,13 +99,9 @@ class TestCheckpointManager:
 
     def test_save_options(self, temp_dir, simple_model, simple_optimizer):
         """Test saving with options disabled."""
-        manager = CheckpointManager(
-            checkpoint_dir=temp_dir, save_optimizer=False, save_scheduler=False
-        )
+        manager = CheckpointManager(checkpoint_dir=temp_dir, save_optimizer=False, save_scheduler=False)
 
-        manager.save_checkpoint(
-            simple_model, optimizer=simple_optimizer, checkpoint_name="ckpt_no_opt"
-        )
+        manager.save_checkpoint(simple_model, optimizer=simple_optimizer, checkpoint_name="ckpt_no_opt")
 
         ckpt_path = temp_dir / "ckpt_no_opt"
         assert (ckpt_path / "model.pt").exists()

--- a/tests/test_utils/test_data.py
+++ b/tests/test_utils/test_data.py
@@ -75,15 +75,11 @@ class TestBatchEncoding:
 
 
 def test_pad_sequences(sample_list_sequences):
-    padded_right = pad_sequences(
-        sample_list_sequences, padding_value=0, padding_side="right"
-    )
+    padded_right = pad_sequences(sample_list_sequences, padding_value=0, padding_side="right")
     expected_right = torch.tensor([[1, 2, 3], [4, 5, 0]])
     assert torch.equal(padded_right, expected_right)
 
-    padded_left = pad_sequences(
-        sample_list_sequences, padding_value=0, padding_side="left"
-    )
+    padded_left = pad_sequences(sample_list_sequences, padding_value=0, padding_side="left")
     expected_left = torch.tensor([[1, 2, 3], [0, 4, 5]])
     assert torch.equal(padded_left, expected_left)
 

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -46,9 +46,7 @@ def temp_dir():
     try:
         shutil.rmtree(temp_dir_path)
     except PermissionError:
-        print(
-            f"Warning: Could not remove temp directory {temp_dir_path} due to PermissionError."
-        )
+        print(f"Warning: Could not remove temp directory {temp_dir_path} due to PermissionError.")
     except OSError as e:
         print(f"Warning: Error removing temp directory {temp_dir_path}: {e}")
 
@@ -89,9 +87,7 @@ class TestLogging:
         # This will create a basic logger since one isn't set up
         logger = get_logger("thinkrl.test_get_new")
         assert logger is not None
-        assert isinstance(
-            logger, logging.Logger
-        )  # get_logger returns base logger if not setup
+        assert isinstance(logger, logging.Logger)  # get_logger returns base logger if not setup
         assert logger.name == "thinkrl.test_get_new"
 
         # Test getting an already configured logger
@@ -139,14 +135,13 @@ class TestLogging:
         )
         assert logger_rank0 is not None
         assert logger_rank0.name == logger_name_rank0  # Check name
-        assert any(
-            isinstance(h, logging.StreamHandler) for h in logger_rank0.handlers
-        ), "Rank 0 should have a StreamHandler"
+        assert any(isinstance(h, logging.StreamHandler) for h in logger_rank0.handlers), (
+            "Rank 0 should have a StreamHandler"
+        )
 
         # UP038 Fix: Combined check using | operator
         assert any(
-            isinstance(h, logging.FileHandler | logging.handlers.RotatingFileHandler)
-            for h in logger_rank0.handlers
+            isinstance(h, logging.FileHandler | logging.handlers.RotatingFileHandler) for h in logger_rank0.handlers
         ), "Rank 0 should have a FileHandler"
 
         logger_rank0.info("Rank 0 message")
@@ -166,9 +161,7 @@ class TestLogging:
         assert logger_rank1_file is not None
         assert logger_rank1_file.name == logger_name_rank1  # Check name
         # Assert ONLY FileHandler (or RotatingFileHandler) exists
-        assert len(logger_rank1_file.handlers) == 1, (
-            "Rank 1 with log_dir should have exactly one handler"
-        )
+        assert len(logger_rank1_file.handlers) == 1, "Rank 1 with log_dir should have exactly one handler"
 
         # UP038 Fix: Using | instead of tuple (,)
         assert isinstance(
@@ -179,9 +172,7 @@ class TestLogging:
         logger_rank1_file.info("Rank 1 message to file")
         # Check that the file was actually created using the correct name pattern
         rank1_log_files = list(temp_dir.glob(f"{logger_name_rank1}_*.log"))
-        assert len(rank1_log_files) == 1, (
-            f"Log file matching {logger_name_rank1}_*.log for rank 1 should exist"
-        )
+        assert len(rank1_log_files) == 1, f"Log file matching {logger_name_rank1}_*.log for rank 1 should exist"
 
         # --- FIX: Clear handlers for rank 1 logger BEFORE reconfiguring ---
         # Get the logger instance directly
@@ -200,21 +191,15 @@ class TestLogging:
             base_name=base_name_for_test,  # log_dir is None
         )
         assert logger_rank1_null is not None
-        assert (
-            logger_rank1_null.name == logger_name_rank1
-        )  # Should be the same logger instance
+        assert logger_rank1_null.name == logger_name_rank1  # Should be the same logger instance
 
         # Assert NullHandler is present and ONLY handler
-        assert len(logger_rank1_null.handlers) == 1, (
-            "Rank 1 without log_dir should have exactly one handler"
-        )
+        assert len(logger_rank1_null.handlers) == 1, "Rank 1 without log_dir should have exactly one handler"
         assert isinstance(logger_rank1_null.handlers[0], logging.NullHandler), (
             "Rank 1 without log_dir should have NullHandler"
         )
 
-        logger_rank1_null.info(
-            "This rank 1 message should NOT appear anywhere"
-        )  # Test it doesn't log
+        logger_rank1_null.info("This rank 1 message should NOT appear anywhere")  # Test it doesn't log
 
     def test_thinkrl_logger_methods(self, temp_dir):
         """Test the custom methods of ThinkRLLogger."""

--- a/tests/test_utils/test_metrics.py
+++ b/tests/test_utils/test_metrics.py
@@ -94,21 +94,15 @@ class TestMetrics:
         log_probs_policy = torch.log(torch.tensor([0.2, 0.3, 0.5]))
         log_probs_ref = torch.log(torch.tensor([0.1, 0.4, 0.5]))
 
-        kl_div_mean = compute_kl_divergence(
-            log_probs_policy, log_probs_ref, reduction="mean"
-        )
+        kl_div_mean = compute_kl_divergence(log_probs_policy, log_probs_ref, reduction="mean")
         assert isinstance(kl_div_mean, torch.Tensor)
         assert kl_div_mean.dim() == 0
 
-        kl_div_sum = compute_kl_divergence(
-            log_probs_policy, log_probs_ref, reduction="sum"
-        )
+        kl_div_sum = compute_kl_divergence(log_probs_policy, log_probs_ref, reduction="sum")
         assert kl_div_sum.dim() == 0
         assert kl_div_sum == pytest.approx(kl_div_mean * 3)
 
-        kl_div_none = compute_kl_divergence(
-            log_probs_policy, log_probs_ref, reduction="none"
-        )
+        kl_div_none = compute_kl_divergence(log_probs_policy, log_probs_ref, reduction="none")
         assert kl_div_none.dim() == 1
         assert kl_div_none.shape == (3,)
 
@@ -116,9 +110,7 @@ class TestMetrics:
         rewards = torch.randn(4, 10)
         values = torch.randn(4, 10)
 
-        advantages = compute_advantages(
-            rewards=rewards, values=values, gamma=0.99, lambda_=0.95, normalize=True
-        )
+        advantages = compute_advantages(rewards=rewards, values=values, gamma=0.99, lambda_=0.95, normalize=True)
         assert advantages.shape == rewards.shape
         assert torch.abs(advantages.mean()) < 1e-6
         assert torch.abs(advantages.std() - 1.0) < 1e-5
@@ -170,9 +162,7 @@ class TestMetrics:
 
         targets_with_ignore = torch.tensor([[1, 2, 0], [1, -100, 1]])
         predictions_ignore = torch.tensor([[1, 2, 3], [1, 1, 1]])
-        accuracy_ignore = compute_accuracy(
-            predictions_ignore, targets_with_ignore, ignore_index=-100
-        )
+        accuracy_ignore = compute_accuracy(predictions_ignore, targets_with_ignore, ignore_index=-100)
         assert accuracy_ignore == pytest.approx(4 / 5)
 
     def test_compute_perplexity(self):
@@ -330,15 +320,9 @@ class TestMetrics:
 
         group_metrics = compute_group_metrics(rewards, group_ids)
 
-        assert torch.allclose(
-            group_metrics["group_means"], torch.tensor([2.0, 10.5, 20.0])
-        )
-        assert torch.allclose(
-            group_metrics["group_maxs"], torch.tensor([3.0, 11.0, 20.0])
-        )
-        assert torch.allclose(
-            group_metrics["group_mins"], torch.tensor([1.0, 10.0, 20.0])
-        )
+        assert torch.allclose(group_metrics["group_means"], torch.tensor([2.0, 10.5, 20.0]))
+        assert torch.allclose(group_metrics["group_maxs"], torch.tensor([3.0, 11.0, 20.0]))
+        assert torch.allclose(group_metrics["group_mins"], torch.tensor([1.0, 10.0, 20.0]))
 
     def test_compute_ranking_metrics(self):
         scores = torch.tensor([0.9, 0.7, 0.5, 0.3, 0.1])
@@ -379,9 +363,7 @@ class TestMetrics:
         # Use xp (numpy/cupy) for assertion
         assert metrics["perplexity"] == pytest.approx(float(xp.exp(1.2)))
 
-        metrics_subset = compute_metrics(
-            outputs, targets, metric_names=["accuracy", "loss"]
-        )
+        metrics_subset = compute_metrics(outputs, targets, metric_names=["accuracy", "loss"])
 
         assert "accuracy" in metrics_subset
         assert "perplexity" not in metrics_subset

--- a/tests/test_utils/test_tokenizer.py
+++ b/tests/test_utils/test_tokenizer.py
@@ -40,9 +40,7 @@ except ImportError:
     _TRANSFORMERS_AVAILABLE = False
 
 # Skip all tests in this file if transformers is not installed
-pytestmark = pytest.mark.skipif(
-    not _TRANSFORMERS_AVAILABLE, reason="transformers not installed"
-)
+pytestmark = pytest.mark.skipif(not _TRANSFORMERS_AVAILABLE, reason="transformers not installed")
 
 
 @pytest.fixture(scope="module")
@@ -79,9 +77,7 @@ class TestTokenizers:
     def test_tokenize_text(self, gpt2_tokenizer):
         """Test text tokenization for single string and batch."""
         text = "Hello, world!"
-        encoded = tokenize_text(
-            text, gpt2_tokenizer, max_length=10, padding="max_length", truncation=True
-        )
+        encoded = tokenize_text(text, gpt2_tokenizer, max_length=10, padding="max_length", truncation=True)
 
         assert "input_ids" in encoded
         assert "attention_mask" in encoded
@@ -90,9 +86,7 @@ class TestTokenizers:
 
         # Test batch
         texts = ["Hello!", "How are you?"]
-        encoded_batch = tokenize_text(
-            texts, gpt2_tokenizer, padding=True, return_tensors="pt"
-        )
+        encoded_batch = tokenize_text(texts, gpt2_tokenizer, padding=True, return_tensors="pt")
         assert encoded_batch["input_ids"].shape[0] == 2
         assert encoded_batch["input_ids"].shape[1] >= 3
 
@@ -101,9 +95,7 @@ class TestTokenizers:
         texts = ["Text 1", "Text 2", "A slightly longer text"] * 10
 
         # Test with batch_size
-        encoded = tokenize_batch(
-            texts, gpt2_tokenizer, max_length=10, padding="max_length", batch_size=8
-        )
+        encoded = tokenize_batch(texts, gpt2_tokenizer, max_length=10, padding="max_length", batch_size=8)
 
         assert "input_ids" in encoded
         assert "attention_mask" in encoded
@@ -115,16 +107,12 @@ class TestTokenizers:
         text = "Hello, world!"
         token_ids = gpt2_tokenizer.encode(text)
 
-        decoded_text = decode_tokens(
-            token_ids, gpt2_tokenizer, skip_special_tokens=True
-        )
+        decoded_text = decode_tokens(token_ids, gpt2_tokenizer, skip_special_tokens=True)
         assert decoded_text == text
 
         texts = ["Hello!", "How are you?"]
         batch_ids = [gpt2_tokenizer.encode(t) for t in texts]
-        decoded_batch = decode_tokens(
-            batch_ids, gpt2_tokenizer, skip_special_tokens=True
-        )
+        decoded_batch = decode_tokens(batch_ids, gpt2_tokenizer, skip_special_tokens=True)
 
         assert isinstance(decoded_batch, list)
         assert len(decoded_batch) == 2
@@ -146,16 +134,12 @@ class TestTokenizers:
         tokenizer = get_tokenizer("gpt2")
         original_vocab_size = len(tokenizer)
 
-        num_added = add_special_tokens(
-            tokenizer, {"additional_special_tokens": ["<|user|>", "<|assistant|>"]}
-        )
+        num_added = add_special_tokens(tokenizer, {"additional_special_tokens": ["<|user|>", "<|assistant|>"]})
 
         assert num_added == 2
         assert len(tokenizer) == original_vocab_size + 2
         assert tokenizer.convert_tokens_to_ids("<|user|>") == original_vocab_size
-        assert (
-            tokenizer.convert_tokens_to_ids("<|assistant|>") == original_vocab_size + 1
-        )
+        assert tokenizer.convert_tokens_to_ids("<|assistant|>") == original_vocab_size + 1
 
     def test_tokenize_conversation_manual(self, gpt2_tokenizer):
         """Test conversation tokenization using manual formatting."""
@@ -202,9 +186,7 @@ class TestTokenizers:
 
             tokenize_conversation(messages, mock_tokenizer, add_generation_prompt=True)
 
-            mock_tokenizer.apply_chat_template.assert_called_with(
-                messages, tokenize=False, add_generation_prompt=True
-            )
+            mock_tokenizer.apply_chat_template.assert_called_with(messages, tokenize=False, add_generation_prompt=True)
 
             mock_tokenize_text.assert_called_with("Template output", mock_tokenizer)
 
@@ -233,14 +215,10 @@ class TestTokenizers:
         """Test truncating text based on token count."""
         long_text = "This is a very long text that will surely be truncated."
 
-        truncated_right = truncate_to_token_limit(
-            long_text, gpt2_tokenizer, max_tokens=7
-        )
+        truncated_right = truncate_to_token_limit(long_text, gpt2_tokenizer, max_tokens=7)
         assert truncated_right == "This is a very long text that"
 
-        truncated_left = truncate_to_token_limit(
-            long_text, gpt2_tokenizer, max_tokens=7, side="left"
-        )
+        truncated_left = truncate_to_token_limit(long_text, gpt2_tokenizer, max_tokens=7, side="left")
         assert truncated_left == " that will surely be truncated."
 
     def test_get_tokenizer_info(self, gpt2_tokenizer):
@@ -259,9 +237,7 @@ class TestTokenizers:
     def test_save_and_load_tokenizer(self, temp_dir):
         """Test saving and loading a modified tokenizer."""
         tokenizer_to_save = get_tokenizer("gpt2")
-        add_special_tokens(
-            tokenizer_to_save, {"additional_special_tokens": ["<|my_token|>"]}
-        )
+        add_special_tokens(tokenizer_to_save, {"additional_special_tokens": ["<|my_token|>"]})
 
         assert tokenizer_to_save.convert_tokens_to_ids("<|my_token|>") == 50257
 
@@ -272,9 +248,7 @@ class TestTokenizers:
 
         loaded_tokenizer = load_tokenizer(temp_dir)
 
-        assert isinstance(
-            loaded_tokenizer, PreTrainedTokenizer | PreTrainedTokenizerFast
-        )
+        assert isinstance(loaded_tokenizer, PreTrainedTokenizer | PreTrainedTokenizerFast)
         assert len(loaded_tokenizer) == len(tokenizer_to_save)
         assert loaded_tokenizer.convert_tokens_to_ids("<|my_token|>") == 50257
         assert loaded_tokenizer.pad_token_id == 50256

--- a/thinkrl/data/datasets.py
+++ b/thinkrl/data/datasets.py
@@ -58,9 +58,7 @@ class BaseRLHFDataset(Dataset):
             # Load dataset
             if isinstance(dataset_name_or_path, str):
                 if dataset_name_or_path.endswith((".json", ".jsonl")):
-                    self.dataset = load_dataset(
-                        "json", data_files=dataset_name_or_path, split=split
-                    )
+                    self.dataset = load_dataset("json", data_files=dataset_name_or_path, split=split)
                 else:
                     self.dataset = load_dataset(dataset_name_or_path, split=split)
             else:
@@ -123,9 +121,7 @@ class RLHFDataset(BaseRLHFDataset):
             item[self.prompt_column] = prompt.strip()
             self.data.append(item)
 
-        logger.info(
-            f"Loaded {len(self.data)} valid samples from {dataset_name_or_path}"
-        )
+        logger.info(f"Loaded {len(self.data)} valid samples from {dataset_name_or_path}")
 
     def __getitem__(self, idx: int) -> dict[str, Any]:
         sample = self.data[idx]
@@ -202,9 +198,7 @@ class PreferenceDataset(BaseRLHFDataset):
             item[self.rejected_column] = rejected.strip()
             self.data.append(item)
 
-        logger.info(
-            f"Loaded {len(self.data)} valid preference pairs from {dataset_name_or_path}"
-        )
+        logger.info(f"Loaded {len(self.data)} valid preference pairs from {dataset_name_or_path}")
 
     def __getitem__(self, idx: int) -> dict[str, Any]:
         sample = self.data[idx]

--- a/thinkrl/data/loaders.py
+++ b/thinkrl/data/loaders.py
@@ -24,9 +24,7 @@ def create_rlhf_collate_fn(tokenizer, padding_side="right"):
         keys = batch[0].keys()
         collated = {}
 
-        padding_value = (
-            tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0
-        )
+        padding_value = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0
 
         for key in keys:
             if key in ["prompt_text", "prompt"]:  # Pass through strings
@@ -41,14 +39,10 @@ def create_rlhf_collate_fn(tokenizer, padding_side="right"):
                 if padding_side == "left":
                     # Reverse, pad, reverse back for left padding
                     tensors_rev = [t.flip(0) for t in tensors]
-                    padded_rev = pad_sequence(
-                        tensors_rev, batch_first=True, padding_value=padding_value
-                    )
+                    padded_rev = pad_sequence(tensors_rev, batch_first=True, padding_value=padding_value)
                     collated[key] = padded_rev.flip(1)
                 else:
-                    collated[key] = pad_sequence(
-                        tensors, batch_first=True, padding_value=padding_value
-                    )
+                    collated[key] = pad_sequence(tensors, batch_first=True, padding_value=padding_value)
             else:
                 # Fallback for other types
                 collated[key] = [item[key] for item in batch]

--- a/thinkrl/data/processors.py
+++ b/thinkrl/data/processors.py
@@ -45,9 +45,7 @@ def process_image(image_path: str, transform: Any | None = None) -> Any | None:
         return None
 
 
-def process_audio(
-    audio_path: str, sr: int = 16000, transform: Any | None = None
-) -> Any | None:
+def process_audio(audio_path: str, sr: int = 16000, transform: Any | None = None) -> Any | None:
     """
     Load and process an audio file.
     """

--- a/thinkrl/utils/checkpoint.py
+++ b/thinkrl/utils/checkpoint.py
@@ -116,8 +116,7 @@ class CheckpointManager:
 
         if self.use_safetensors and not _SAFETENSORS_AVAILABLE:
             logger.warning(
-                "SafeTensors not available. Falling back to PyTorch format. "
-                "Install with: pip install safetensors"
+                "SafeTensors not available. Falling back to PyTorch format. Install with: pip install safetensors"
             )
             self.use_safetensors = False
 
@@ -269,9 +268,7 @@ class CheckpointManager:
 
         # Load model state
         if model_path.suffix == ".safetensors":
-            state_dict = safetensors_load(
-                str(model_path), device=str(device) if device else "cpu"
-            )
+            state_dict = safetensors_load(str(model_path), device=str(device) if device else "cpu")
         else:
             state_dict = torch.load(model_path, map_location=device)
 
@@ -286,18 +283,14 @@ class CheckpointManager:
         if optimizer is not None:
             optimizer_path = checkpoint_dir / "optimizer.pt"
             if optimizer_path.exists():
-                optimizer.load_state_dict(
-                    torch.load(optimizer_path, map_location=device)
-                )
+                optimizer.load_state_dict(torch.load(optimizer_path, map_location=device))
                 logger.debug(f"Loaded optimizer from: {optimizer_path}")
 
         # Load scheduler
         if scheduler is not None:
             scheduler_path = checkpoint_dir / "scheduler.pt"
             if scheduler_path.exists():
-                scheduler.load_state_dict(
-                    torch.load(scheduler_path, map_location=device)
-                )
+                scheduler.load_state_dict(torch.load(scheduler_path, map_location=device))
                 logger.debug(f"Loaded scheduler from: {scheduler_path}")
 
         # Load metadata
@@ -349,9 +342,7 @@ class CheckpointManager:
 
         return metadata
 
-    def _update_best_checkpoint(
-        self, checkpoint_info: dict[str, Any], metric_value: float
-    ):
+    def _update_best_checkpoint(self, checkpoint_info: dict[str, Any], metric_value: float):
         """Update the best checkpoint based on metric value."""
         if self.best_checkpoint is None:
             self.best_checkpoint = checkpoint_info
@@ -366,10 +357,7 @@ class CheckpointManager:
 
         if is_better:
             self.best_checkpoint = checkpoint_info
-            logger.info(
-                f"New best checkpoint: {self.metric_name}={metric_value:.4f} "
-                f"(previous: {best_metric:.4f})"
-            )
+            logger.info(f"New best checkpoint: {self.metric_name}={metric_value:.4f} (previous: {best_metric:.4f})")
 
     def _cleanup_checkpoints(self):
         """Remove old checkpoints, keeping only the best ones."""
@@ -383,14 +371,10 @@ class CheckpointManager:
                 return ckpt["metrics"].get(self.metric_name, float("inf"))
 
             reverse = self.mode == "max"
-            sorted_checkpoints = sorted(
-                self.checkpoints, key=get_metric, reverse=reverse
-            )
+            sorted_checkpoints = sorted(self.checkpoints, key=get_metric, reverse=reverse)
         else:
             # Sort by timestamp (keep most recent)
-            sorted_checkpoints = sorted(
-                self.checkpoints, key=lambda x: x["timestamp"], reverse=True
-            )
+            sorted_checkpoints = sorted(self.checkpoints, key=lambda x: x["timestamp"], reverse=True)
 
         # Keep best checkpoints
         keep_checkpoints = sorted_checkpoints[: self.max_checkpoints]
@@ -474,9 +458,7 @@ class CheckpointManager:
                     "metrics": best_ckpt["metrics"],
                 }
 
-            logger.debug(
-                f"Loaded checkpoint metadata: {len(self.checkpoints)} checkpoints"
-            )
+            logger.debug(f"Loaded checkpoint metadata: {len(self.checkpoints)} checkpoints")
 
         except Exception as e:
             logger.warning(f"Failed to load checkpoint metadata: {e}")
@@ -617,9 +599,7 @@ def load_checkpoint(
     # Load checkpoint
     if checkpoint_path.suffix == ".safetensors":
         # Load safetensors model
-        state_dict = safetensors_load(
-            str(checkpoint_path), device=str(device) if device else "cpu"
-        )
+        state_dict = safetensors_load(str(checkpoint_path), device=str(device) if device else "cpu")
 
         # Load metadata
         metadata_path = checkpoint_path.with_suffix(".metadata.json")

--- a/thinkrl/utils/datasets.py
+++ b/thinkrl/utils/datasets.py
@@ -13,9 +13,7 @@ import torch
 class BatchEncoding(dict):
     """Holds the output of the tokenizer."""
 
-    def __init__(
-        self, data: dict[str, Any], encoding: Any = None, tensor_type: str = "pt"
-    ):
+    def __init__(self, data: dict[str, Any], encoding: Any = None, tensor_type: str = "pt"):
         super().__init__(data)
         self.encoding = encoding
         self.tensor_type = tensor_type
@@ -28,9 +26,7 @@ class BatchEncoding(dict):
         return self
 
 
-def pad_sequences(
-    sequences: list[torch.Tensor], padding_value: int = 0, padding_side: str = "right"
-) -> torch.Tensor:
+def pad_sequences(sequences: list[torch.Tensor], padding_value: int = 0, padding_side: str = "right") -> torch.Tensor:
     """Pad a list of sequences to the same length."""
     from torch.nn.utils.rnn import pad_sequence
 
@@ -46,9 +42,7 @@ def pad_sequences(
     return pad_sequence(sequences, batch_first=True, padding_value=padding_value)
 
 
-def create_attention_mask(
-    input_ids: torch.Tensor, padding_value: int = 0
-) -> torch.Tensor:
+def create_attention_mask(input_ids: torch.Tensor, padding_value: int = 0) -> torch.Tensor:
     """Create attention mask from input_ids."""
     return (input_ids != padding_value).long()
 
@@ -77,11 +71,7 @@ def collate_batch(
 
     # Determine padding value
     pad_token_id = 0
-    if (
-        tokenizer is not None
-        and hasattr(tokenizer, "pad_token_id")
-        and tokenizer.pad_token_id is not None
-    ):
+    if tokenizer is not None and hasattr(tokenizer, "pad_token_id") and tokenizer.pad_token_id is not None:
         pad_token_id = tokenizer.pad_token_id
 
     for key in keys:
@@ -113,17 +103,13 @@ def collate_batch(
     return collated
 
 
-def create_dataloader(
-    dataset, batch_size: int, shuffle: bool = True, collate_fn=None, **kwargs
-):
+def create_dataloader(dataset, batch_size: int, shuffle: bool = True, collate_fn=None, **kwargs):
     """Create a PyTorch DataLoader."""
     from torch.utils.data import DataLoader
 
     if collate_fn is None:
         collate_fn = collate_batch
-    return DataLoader(
-        dataset, batch_size=batch_size, shuffle=shuffle, collate_fn=collate_fn, **kwargs
-    )
+    return DataLoader(dataset, batch_size=batch_size, shuffle=shuffle, collate_fn=collate_fn, **kwargs)
 
 
 def preprocess_text(text: str) -> str:
@@ -133,9 +119,7 @@ def preprocess_text(text: str) -> str:
     return text.strip()
 
 
-def truncate_sequence(
-    sequence: list | torch.Tensor, max_length: int, side: str = "right"
-) -> list | torch.Tensor:
+def truncate_sequence(sequence: list | torch.Tensor, max_length: int, side: str = "right") -> list | torch.Tensor:
     """Truncate a sequence to max_length."""
     if len(sequence) <= max_length:
         return sequence
@@ -146,16 +130,12 @@ def truncate_sequence(
         return sequence[-max_length:]
 
 
-def create_labels_for_clm(
-    input_ids: torch.Tensor, ignore_index: int = -100
-) -> torch.Tensor:
+def create_labels_for_clm(input_ids: torch.Tensor, ignore_index: int = -100) -> torch.Tensor:
     """Create labels for Causal Language Modeling (usually same as input_ids)."""
     return input_ids.clone()
 
 
-def mask_padding_in_loss(
-    labels: torch.Tensor, attention_mask: torch.Tensor, ignore_index: int = -100
-) -> torch.Tensor:
+def mask_padding_in_loss(labels: torch.Tensor, attention_mask: torch.Tensor, ignore_index: int = -100) -> torch.Tensor:
     """Mask padding tokens in labels so they don't contribute to loss."""
     labels = labels.clone()
     labels[attention_mask == 0] = ignore_index
@@ -229,8 +209,6 @@ def to_device(batch: dict[str, Any], device: str | torch.device) -> dict[str, An
     return new_batch
 
 
-def prepare_batch_for_training(
-    batch: dict[str, Any], device: str | torch.device
-) -> dict[str, Any]:
+def prepare_batch_for_training(batch: dict[str, Any], device: str | torch.device) -> dict[str, Any]:
     """Prepare batch for training (move to device, etc.)."""
     return to_device(batch, device)

--- a/thinkrl/utils/logging.py
+++ b/thinkrl/utils/logging.py
@@ -329,10 +329,7 @@ def setup_logger(
 
     # Default format strings
     if format_string is None:
-        format_string = (
-            "%(asctime)s - %(name)s - %(levelname)s - "
-            "%(filename)s:%(lineno)d - %(message)s"
-        )
+        format_string = "%(asctime)s - %(name)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s"
 
     if date_format is None:
         date_format = "%Y-%m-%d %H:%M:%S"
@@ -340,9 +337,7 @@ def setup_logger(
     # Console handler with colors (always add for rank 0 or non-distributed)
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(level)
-    console_formatter = ColoredFormatter(
-        fmt=format_string, datefmt=date_format, use_colors=use_colors
-    )
+    console_formatter = ColoredFormatter(fmt=format_string, datefmt=date_format, use_colors=use_colors)
     console_handler.setFormatter(console_formatter)
     logger.addHandler(console_handler)
 
@@ -371,12 +366,8 @@ def setup_logger(
             )
         except ImportError:
             # Fallback to regular file handler
-            warnings.warn(
-                "RotatingFileHandler not available. Using standard FileHandler."
-            )
-            file_handler = logging.FileHandler(
-                filename=str(log_path), mode=file_mode, encoding="utf-8"
-            )
+            warnings.warn("RotatingFileHandler not available. Using standard FileHandler.")
+            file_handler = logging.FileHandler(filename=str(log_path), mode=file_mode, encoding="utf-8")
 
         file_handler.setLevel(level)
 
@@ -413,11 +404,7 @@ def get_logger(name: str = "thinkrl", level: int | str | None = None) -> logging
 
     # If logger has no handlers AND is not disabled (level > CRITICAL), set it up.
     # Check for level NOTSET as well, as getLogger returns a logger with NOTSET by default.
-    if (
-        not logger.handlers
-        and logger.level <= logging.CRITICAL
-        and logger.level != logging.NOTSET
-    ):
+    if not logger.handlers and logger.level <= logging.CRITICAL and logger.level != logging.NOTSET:
         # Use provided level or default to INFO if creating handlers
         effective_level = level
         if effective_level is None:
@@ -464,9 +451,7 @@ def configure_logging_for_distributed(
             pass
         logger.removeHandler(h)
 
-    fmt = (
-        "%(asctime)s - %(name)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s"
-    )
+    fmt = "%(asctime)s - %(name)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s"
     formatter = logging.Formatter(fmt)
 
     if rank == 0:
@@ -477,9 +462,7 @@ def configure_logging_for_distributed(
         logger.addHandler(sh)
         # file (if requested)
         if log_dir is not None:
-            log_path = (
-                Path(log_dir) / f"{logger_name}_{datetime.now():%Y%m%d_%H%M%S}.log"
-            )
+            log_path = Path(log_dir) / f"{logger_name}_{datetime.now():%Y%m%d_%H%M%S}.log"
             fh = logging.FileHandler(log_path, encoding="utf-8")
             fh.setLevel(level)
             fh.setFormatter(formatter)
@@ -487,9 +470,7 @@ def configure_logging_for_distributed(
     else:
         if log_dir is not None:
             # file-only for nonzero ranks
-            log_path = (
-                Path(log_dir) / f"{logger_name}_{datetime.now():%Y%m%d_%H%M%S}.log"
-            )
+            log_path = Path(log_dir) / f"{logger_name}_{datetime.now():%Y%m%d_%H%M%S}.log"
             fh = logging.FileHandler(log_path, encoding="utf-8")
             fh.setLevel(level)
             fh.setFormatter(formatter)

--- a/thinkrl/utils/tokenizer.py
+++ b/thinkrl/utils/tokenizer.py
@@ -149,8 +149,7 @@ def get_tokenizer(
     """
     if not _TRANSFORMERS_AVAILABLE:
         raise ImportError(
-            "transformers is required for tokenizer functionality. "
-            "Install with: pip install transformers"
+            "transformers is required for tokenizer functionality. Install with: pip install transformers"
         )
 
     logger.info(f"Loading tokenizer from: {model_name_or_path}")
@@ -181,10 +180,7 @@ def get_tokenizer(
             tokenizer.add_special_tokens({"pad_token": "[PAD]"})
             logger.info("Added new pad_token: [PAD]")
 
-    logger.info(
-        f"Tokenizer loaded: vocab_size={tokenizer.vocab_size}, "
-        f"padding_side={tokenizer.padding_side}"
-    )
+    logger.info(f"Tokenizer loaded: vocab_size={tokenizer.vocab_size}, padding_side={tokenizer.padding_side}")
 
     return tokenizer
 
@@ -462,10 +458,7 @@ def add_special_tokens(
     if num_added > 0:
         logger.info(f"Added {num_added} special tokens to tokenizer")
         if resize_embeddings:
-            logger.info(
-                "Remember to resize model embeddings: "
-                "model.resize_token_embeddings(len(tokenizer))"
-            )
+            logger.info("Remember to resize model embeddings: model.resize_token_embeddings(len(tokenizer))")
 
     return num_added
 
@@ -515,19 +508,12 @@ def tokenize_conversation(
         ```
     """
     # Try using chat template if available
-    if (
-        hasattr(tokenizer, "apply_chat_template")
-        and tokenizer.chat_template is not None
-    ):
+    if hasattr(tokenizer, "apply_chat_template") and tokenizer.chat_template is not None:
         try:
-            text = tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=add_generation_prompt
-            )
+            text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=add_generation_prompt)
             return tokenize_text(text, tokenizer, **kwargs)
         except Exception as e:
-            logger.warning(
-                f"Failed to use chat template: {e}, falling back to manual formatting"
-            )
+            logger.warning(f"Failed to use chat template: {e}, falling back to manual formatting")
 
     # Manual formatting
     formatted_messages = []
@@ -689,9 +675,7 @@ def truncate_to_token_limit(
         truncated_ids = token_ids[-max_tokens:]
 
     # Decode back to text
-    truncated_text = tokenizer.decode(
-        truncated_ids, skip_special_tokens=not add_special_tokens
-    )
+    truncated_text = tokenizer.decode(truncated_ids, skip_special_tokens=not add_special_tokens)
 
     return truncated_text
 
@@ -732,9 +716,7 @@ def get_tokenizer_info(tokenizer: TokenizerType) -> dict[str, Any]:
     return info
 
 
-def save_tokenizer(
-    tokenizer: TokenizerType, save_directory: str | Path, **kwargs
-) -> tuple[str, ...]:
+def save_tokenizer(tokenizer: TokenizerType, save_directory: str | Path, **kwargs) -> tuple[str, ...]:
     """
     Save tokenizer to directory.
 
@@ -783,9 +765,7 @@ def load_tokenizer(load_directory: str | Path, **kwargs) -> TokenizerType:
         ```
     """
     if not _TRANSFORMERS_AVAILABLE:
-        raise ImportError(
-            "transformers is required. Install with: pip install transformers"
-        )
+        raise ImportError("transformers is required. Install with: pip install transformers")
 
     tokenizer = AutoTokenizer.from_pretrained(str(load_directory), **kwargs)
 


### PR DESCRIPTION
- Remove trailing whitespace from workflow YAML files
- Remove trailing whitespace from README.md and CONTRIBUTION.md
- Apply ruff format to 18 Python files
- Ensure proper EOF newlines across all files

Fixes pre-commit hook failures for trailing-whitespace, end-of-file-fixer, and ruff-format checks.