### PR TITLE
Set up Python virtual environment and testing

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Run slow tests
         run: |
           source .venv/bin/activate
-          # This runs tests marked with @pytest.mark.slow or matching "slow" keyword
+          # This runs tests marked with @pytest.mark.slow
           # which are explicitly excluded in your main tests.yml
-          pytest tests/ -v -k "slow" --tb=short
+          pytest tests/ -v -m slow --tb=short
         env:
           CUDA_VISIBLE_DEVICES: "" 
           PYTHONPATH: ${{ github.workspace }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,11 +70,11 @@ markers = [
 
 filterwarnings = [
     "ignore:.*transformers not available.*:UserWarning",
-    "error",
     "ignore::UserWarning:torch.utils.checkpoint:",
     "ignore::FutureWarning:transformers.tokenization_utils_base:",
     "ignore::UserWarning:cupy.cuda.memory:",
     "ignore::DeprecationWarning",
+    "error",
 ]
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
- Change from `-k "slow"` to `-m slow` in slow-tests.yml to properly select tests by marker instead of by name pattern
- Move "error" to end of filterwarnings to ensure ignore patterns work

The `-k` option matches by test name, but no tests have "slow" in their name, causing all 90 tests to be deselected. Using `-m slow` properly selects tests marked with @pytest.mark.slow marker.