### PR TITLE
Set up Python virtual environment and testing

### DIFF
--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -126,6 +126,7 @@ def temp_jsonl_file():
                 pass  # Ignore if still locked on Windows in edge cases
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not _DATASETS_AVAILABLE, reason="datasets library not installed")
 class TestRLHFDataset:
     """Tests for the RLHFDataset class."""
@@ -219,6 +220,7 @@ class TestRLHFDataset:
             _ = dataset[-5]
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not _DATASETS_AVAILABLE, reason="datasets library not installed")
 class TestPreferenceDataset:
     """Tests for the PreferenceDataset class."""

--- a/tests/test_data/test_loaders.py
+++ b/tests/test_data/test_loaders.py
@@ -15,6 +15,10 @@ from torch.utils.data import Dataset
 from thinkrl.data.loaders import RLHFDataLoader, create_rlhf_collate_fn
 
 
+# Mark all tests in this module as slow
+pytestmark = pytest.mark.slow
+
+
 # --- Mocks and Fixtures ---
 
 

--- a/tests/test_data/test_processors.py
+++ b/tests/test_data/test_processors.py
@@ -34,6 +34,7 @@ except ImportError:
 # --- Image Processor Tests ---
 
 
+@pytest.mark.slow
 class TestProcessImage:
     @pytest.mark.skipif(not _PIL_AVAILABLE, reason="Pillow not installed")
     @patch("thinkrl.data.processors._PIL_AVAILABLE", True)
@@ -102,6 +103,7 @@ class TestProcessImage:
 # --- Audio Processor Tests ---
 
 
+@pytest.mark.slow
 class TestProcessAudio:
     @pytest.mark.skipif(not _AUDIO_AVAILABLE, reason="Librosa not installed")
     @patch("thinkrl.data.processors._AUDIO_AVAILABLE", True)

--- a/tests/test_utils/test_checkpoint.py
+++ b/tests/test_utils/test_checkpoint.py
@@ -48,6 +48,7 @@ def simple_optimizer(simple_model):
 # Tests
 
 
+@pytest.mark.slow
 class TestCheckpointManager:
     """Tests for CheckpointManager."""
 
@@ -133,6 +134,7 @@ class TestCheckpointManager:
             assert not (temp_dir / "ckpt_fallback" / "model.safetensors").exists()
 
 
+@pytest.mark.slow
 class TestStandaloneFunctions:
     """Tests for standalone save/load functions."""
 

--- a/tests/test_utils/test_data.py
+++ b/tests/test_utils/test_data.py
@@ -39,6 +39,10 @@ from thinkrl.utils.datasets import (
 )
 
 
+# Mark all tests in this module as slow
+pytestmark = pytest.mark.slow
+
+
 @pytest.fixture
 def sample_batch_tensors():
     return {

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -58,6 +58,7 @@ def temp_dir():
 # ============================================================================
 
 
+@pytest.mark.slow
 class TestLogging:
     """Test logging utilities."""
 

--- a/tests/test_utils/test_metrics.py
+++ b/tests/test_utils/test_metrics.py
@@ -42,6 +42,7 @@ from thinkrl.utils.metrics import (
 xp = cp if _CUPY_AVAILABLE else np
 
 
+@pytest.mark.slow
 class TestMetrics:
     """Test metrics utilities."""
 

--- a/tests/test_utils/test_tokenizer.py
+++ b/tests/test_utils/test_tokenizer.py
@@ -61,6 +61,7 @@ def temp_dir():
     shutil.rmtree(d)
 
 
+@pytest.mark.slow
 class TestTokenizers:
     """Test tokenizer utilities (requires transformers)."""
 


### PR DESCRIPTION
Add @pytest.mark.slow decorator to test classes and modules that perform file I/O, data loading, and other operations for the slow-tests workflow.

Files marked as slow:
- test_data/test_datasets.py
- test_data/test_loaders.py
- test_data/test_processors.py
- test_utils/test_checkpoint.py
- test_utils/test_data.py
- test_utils/test_logging.py
- test_utils/test_metrics.py
- test_utils/test_tokenizer.py