### PR TITLE
Fix Python 3.10 compatibility and algorithm issues

### DIFF
--- a/thinkrl/utils/checkpoint.py
+++ b/thinkrl/utils/checkpoint.py
@@ -46,6 +46,13 @@ try:
 except ImportError:
     _SAFETENSORS_AVAILABLE = False
 
+    # Define stubs to avoid NameError when safetensors is not available
+    def safetensors_save(*args, **kwargs):
+        raise ImportError("safetensors is not installed. Install with: pip install safetensors")
+
+    def safetensors_load(*args, **kwargs):
+        raise ImportError("safetensors is not installed. Install with: pip install safetensors")
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Add stub functions for safetensors_save and safetensors_load when safetensors is not installed to prevent NameError
- Update test_save_load_safetensors_forced to skip when safetensors is not installed instead of mocking availability flag