### PR TITLE
Update tests for algorithm implementation fixes

### DIFF
--- a/tests/test_algorithms/base.py
+++ b/tests/test_algorithms/base.py
@@ -91,6 +91,7 @@ def sample_batch():
         "attention_mask": torch.ones(batch_size, seq_len, dtype=torch.long),
         "labels": torch.randint(0, 100, (batch_size, seq_len)),
         "rewards": torch.randn(batch_size),
+        "old_log_probs": torch.randn(batch_size, seq_len),  # Required for compute_loss
     }
 
 
@@ -110,7 +111,7 @@ class TestDAPOConfig:
         assert config.group_size == 16
         assert config.beta == 0.0
         assert config.n_epochs == 1
-        assert config.dynamic_sampling is True
+        assert config.dynamic_sampling is False  # Changed to False for DDP safety
         assert config.use_overlong_punishment is True
 
     def test_custom_values(self):
@@ -384,12 +385,30 @@ class TestDAPOAlgorithm:
         """Test advantage computation."""
         rewards = torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
 
-        advantages = dapo_algorithm.compute_advantages(rewards)
+        # compute_advantages now returns (advantages, valid_mask) tuple
+        advantages, valid_mask = dapo_algorithm.compute_advantages(rewards)
 
         assert advantages.shape == rewards.shape
+        assert valid_mask.shape == rewards.shape
+        # All samples should be valid (non-zero variance groups)
+        assert valid_mask.all()
         # Check normalization within groups
         grouped = advantages.view(2, 4)
         assert torch.allclose(grouped.mean(dim=1), torch.zeros(2), atol=1e-6)
+
+    def test_compute_advantages_zero_variance_masking(self, dapo_algorithm):
+        """Test that zero-variance groups are masked instead of rejected (DDP-safe)."""
+        # Two groups: first has variance, second has zero variance
+        rewards = torch.tensor([0.0, 1.0, 2.0, 3.0, 5.0, 5.0, 5.0, 5.0])
+
+        advantages, valid_mask = dapo_algorithm.compute_advantages(rewards)
+
+        assert advantages.shape == (8,)
+        assert valid_mask.shape == (8,)
+        # First group should be valid
+        assert valid_mask[:4].all()
+        # Second group should be masked (zero variance)
+        assert not valid_mask[4:].any()
 
     def test_compute_overlong_penalty_no_penalty(self, dapo_algorithm):
         """Test no penalty for short sequences."""
@@ -439,13 +458,17 @@ class TestDAPOAlgorithm:
         assert "advantage_mean" in loss_dict
         assert "reward_mean" in loss_dict
         assert "ratio_mean" in loss_dict
+        assert "masked_group_ratio" in loss_dict  # DDP-safe masking metric
 
         assert loss_dict["loss"].requires_grad
 
     def test_compute_loss_with_old_log_probs(self, dapo_algorithm, sample_batch):
-        """Test loss computation with pre-computed old_log_probs."""
+        """Test loss computation with pre-computed old_log_probs in batch."""
+        # Compute old_log_probs and add to batch
         old_log_probs = dapo_algorithm.compute_rollout_log_probs(sample_batch)
-        loss_dict = dapo_algorithm.compute_loss(sample_batch, old_log_probs)
+        sample_batch["old_log_probs"] = old_log_probs
+
+        loss_dict = dapo_algorithm.compute_loss(sample_batch)
 
         assert "loss" in loss_dict
         assert loss_dict["loss"].requires_grad
@@ -460,6 +483,7 @@ class TestDAPOAlgorithm:
             "attention_mask": torch.ones(8, 16, dtype=torch.long),
             "labels": torch.randint(0, 100, (8, 16)),
             "rewards": torch.randn(8),
+            "old_log_probs": torch.randn(8, 16),
         }
 
         loss_dict = algo.compute_loss(batch)
@@ -476,6 +500,7 @@ class TestDAPOAlgorithm:
             "attention_mask": torch.ones(8, 16, dtype=torch.long),
             "labels": torch.randint(0, 100, (8, 16)),
             "rewards": torch.randn(8),
+            "old_log_probs": torch.randn(8, 16),
         }
 
         # Should not raise error
@@ -734,6 +759,7 @@ class TestDAPOIntegration:
             "attention_mask": torch.ones(8, 16, dtype=torch.long),
             "labels": torch.randint(0, 100, (8, 16)),
             "rewards": torch.randn(8),
+            "old_log_probs": torch.randn(8, 16),
         }
 
         loss_dict = algo.compute_loss(batch)
@@ -758,6 +784,7 @@ class TestDAPOIntegration:
             "attention_mask": torch.ones(8, 16, dtype=torch.long),
             "labels": torch.randint(0, 100, (8, 16)),
             "rewards": torch.tensor([1e6, -1e6, 1e6, -1e6, 1e6, -1e6, 1e6, -1e6]),
+            "old_log_probs": torch.randn(8, 16),
         }
 
         loss_dict = algo.compute_loss(batch)
@@ -779,6 +806,7 @@ class TestDAPOIntegration:
             "attention_mask": torch.ones(8, 16, dtype=torch.long),
             "labels": torch.randint(0, 100, (8, 16)),
             "rewards": torch.randn(8),
+            "old_log_probs": torch.randn(8, 16),
         }
 
         loss_dict = algo.compute_loss(batch)
@@ -804,6 +832,7 @@ class TestDAPOEdgeCases:
             "attention_mask": torch.ones(4, 16, dtype=torch.long),
             "labels": torch.randint(0, 100, (4, 16)),
             "rewards": torch.randn(4),
+            "old_log_probs": torch.randn(4, 16),
         }
 
         loss_dict = algo.compute_loss(batch)
@@ -819,6 +848,7 @@ class TestDAPOEdgeCases:
             "attention_mask": torch.ones(4, 16, dtype=torch.long),
             "labels": torch.full((4, 16), -100),  # All masked
             "rewards": torch.randn(4),
+            "old_log_probs": torch.randn(4, 16),
         }
 
         # Should handle gracefully
@@ -835,6 +865,7 @@ class TestDAPOEdgeCases:
             "attention_mask": torch.ones(4, 16, dtype=torch.long),
             "labels": torch.randint(0, 100, (4, 16)),
             "rewards": torch.zeros(4),
+            "old_log_probs": torch.randn(4, 16),
         }
 
         loss_dict = algo.compute_loss(batch)
@@ -842,7 +873,7 @@ class TestDAPOEdgeCases:
         assert not torch.isnan(loss_dict["loss"])
 
     def test_uniform_rewards_in_group(self, simple_model):
-        """Test handling of uniform rewards within group."""
+        """Test handling of uniform rewards within group (masked, not rejected)."""
         config = DAPOConfig(group_size=4, advantage_eps=1e-8)
         algo = DAPOAlgorithm(policy_model=simple_model, config=config)
 
@@ -850,9 +881,12 @@ class TestDAPOEdgeCases:
             "input_ids": torch.randint(0, 100, (4, 16)),
             "attention_mask": torch.ones(4, 16, dtype=torch.long),
             "labels": torch.randint(0, 100, (4, 16)),
-            "rewards": torch.ones(4),  # All same
+            "rewards": torch.ones(4),  # All same - will be masked
+            "old_log_probs": torch.randn(4, 16),
         }
 
-        # Should handle via advantage_eps clamping
+        # Should handle via masking (DDP-safe approach)
         loss_dict = algo.compute_loss(batch)
         assert not torch.isnan(loss_dict["loss"])
+        # The group should be masked (zero variance)
+        assert loss_dict["masked_group_ratio"] == 1.0

--- a/tests/test_algorithms/test_dapo.py
+++ b/tests/test_algorithms/test_dapo.py
@@ -43,7 +43,7 @@ def test_dapo_config_defaults():
     config = DAPOConfig()
     assert config.learning_rate == 1e-6
     assert config.group_size == 16
-    assert config.dynamic_sampling is True
+    assert config.dynamic_sampling is False  # Changed to False for DDP safety
 
 
 def test_dapo_config_validation():
@@ -134,9 +134,13 @@ def test_compute_advantages(dapo_algo):
     # Mean: 25, Std (unbiased): 12.91
     rewards = torch.tensor([10.0, 20.0, 30.0, 40.0])
 
-    adv = dapo_algo.compute_advantages(rewards)
+    # compute_advantages now returns (advantages, valid_mask) tuple
+    adv, valid_mask = dapo_algo.compute_advantages(rewards)
 
     assert adv.shape == (4,)
+    assert valid_mask.shape == (4,)
+    # All samples should be valid (non-zero variance group)
+    assert valid_mask.all()
     # Sum of standardized values should be close to 0
     assert torch.isclose(adv.sum(), torch.tensor(0.0), atol=1e-5)
     # Variance should be close to 1
@@ -147,6 +151,39 @@ def test_compute_advantages(dapo_algo):
     std = torch.tensor([10.0, 20.0, 30.0, 40.0]).std(unbiased=False)
     expected = (rewards - mean) / (std + 1e-8)
     assert torch.allclose(adv, expected, atol=1e-5)
+
+
+def test_compute_advantages_zero_variance_masking(dapo_algo):
+    """Test that zero-variance groups are masked instead of rejected (DDP-safe)."""
+    # Two groups: first has variance, second has zero variance
+    rewards = torch.tensor([10.0, 20.0, 30.0, 40.0, 5.0, 5.0, 5.0, 5.0])
+
+    adv, valid_mask = dapo_algo.compute_advantages(rewards)
+
+    assert adv.shape == (8,)
+    assert valid_mask.shape == (8,)
+    # First group should be valid
+    assert valid_mask[:4].all()
+    # Second group should be masked (zero variance)
+    assert not valid_mask[4:].any()
+
+
+def test_compute_loss_masked_group_ratio(dapo_algo):
+    """Test that masked_group_ratio metric is computed correctly."""
+    batch = {
+        "input_ids": torch.randint(0, 10, (8, 5)),
+        "attention_mask": torch.ones((8, 5)),
+        "labels": torch.randint(0, 10, (8, 5)),
+        # First group has variance, second group has zero variance
+        "rewards": torch.tensor([0.0, 1.0, 2.0, 3.0, 5.0, 5.0, 5.0, 5.0]),
+        "old_log_probs": torch.zeros((8, 5)),
+    }
+
+    loss_dict = dapo_algo.compute_loss(batch)
+
+    assert "masked_group_ratio" in loss_dict
+    # 1 out of 2 groups masked = 0.5 ratio
+    assert torch.isclose(loss_dict["masked_group_ratio"], torch.tensor(0.5), atol=1e-5)
 
 
 def test_overlong_penalty(dapo_algo):

--- a/tests/test_algorithms/test_grpo.py
+++ b/tests/test_algorithms/test_grpo.py
@@ -113,6 +113,9 @@ def test_compute_loss_structure(grpo_algo):
     assert "kl_mean" in loss_dict
     assert "advantage_mean" in loss_dict
     assert "clip_fraction" in loss_dict
+    # New metrics accounting for advantage sign
+    assert "clip_fraction_high" in loss_dict
+    assert "clip_fraction_low" in loss_dict
 
     # Check gradients
     loss = loss_dict["loss"]
@@ -199,3 +202,62 @@ def test_no_ref_model_warning():
         mock_logger.warning.assert_called_with(
             "GRPO initialized without ref_model but beta > 0. KL penalty will be 0."
         )
+
+
+def test_train_on_rollout_kl_early_stop(grpo_algo):
+    """Test that train_on_rollout stops early when KL exceeds max_kl."""
+    grpo_algo.config.n_epochs = 10  # High number of epochs
+
+    batch = {
+        "input_ids": torch.randint(0, 10, (4, 5), dtype=torch.long),
+        "attention_mask": torch.ones((4, 5)),
+        "labels": torch.randint(0, 10, (4, 5), dtype=torch.long),
+        "rewards": torch.randn(4),
+    }
+
+    # Mock compute_rollout_log_probs
+    with patch.object(grpo_algo, "compute_rollout_log_probs") as mock_old_log:
+        mock_old_log.return_value = torch.zeros(4, 5)
+
+        # Mock training_step to return high KL
+        with patch.object(grpo_algo, "training_step") as mock_step:
+            # Return high kl_mean to trigger early stopping
+            mock_step.side_effect = lambda batch, old_log_probs: {"loss": 0.5, "kl_mean": 0.2}
+
+            # Use low max_kl to trigger early stop
+            metrics = grpo_algo.train_on_rollout(batch, max_kl=0.1)
+
+            # Should stop early after first epoch (kl_mean=0.2 > max_kl=0.1)
+            assert len(metrics) == 1
+            assert mock_step.call_count == 1
+
+
+def test_train_on_rollout_custom_max_kl(grpo_algo):
+    """Test that max_kl parameter is respected."""
+    grpo_algo.config.n_epochs = 3
+
+    batch = {
+        "input_ids": torch.randint(0, 10, (4, 5), dtype=torch.long),
+        "attention_mask": torch.ones((4, 5)),
+        "labels": torch.randint(0, 10, (4, 5), dtype=torch.long),
+        "rewards": torch.randn(4),
+    }
+
+    with patch.object(grpo_algo, "compute_rollout_log_probs") as mock_old_log:
+        mock_old_log.return_value = torch.zeros(4, 5)
+
+        with patch.object(grpo_algo, "training_step") as mock_step:
+            # Return moderate kl_mean
+            mock_step.side_effect = lambda batch, old_log_probs: {"loss": 0.5, "kl_mean": 0.15}
+
+            # With default max_kl=0.1, should stop early
+            metrics1 = grpo_algo.train_on_rollout(batch, max_kl=0.1)
+            assert len(metrics1) == 1
+
+            # Reset mock
+            mock_step.reset_mock()
+            mock_step.side_effect = lambda batch, old_log_probs: {"loss": 0.5, "kl_mean": 0.15}
+
+            # With higher max_kl=0.2, should complete all epochs
+            metrics2 = grpo_algo.train_on_rollout(batch, max_kl=0.2)
+            assert len(metrics2) == 3


### PR DESCRIPTION
DAPO tests:
- Update compute_advantages tests to handle new (advantages, valid_mask) tuple return
- Add test_compute_advantages_zero_variance_masking for DDP-safe masking
- Add test_compute_loss_masked_group_ratio metric test
- Update dynamic_sampling default assertion (True -> False)
- Add old_log_probs to all batch fixtures (required by compute_loss)

GRPO tests:
- Add assertions for clip_fraction_high and clip_fraction_low metrics
- Add test_train_on_rollout_kl_early_stop for KL early stopping
- Add test_train_on_rollout_custom_max_kl for max_kl parameter

Base tests (comprehensive):
- Update sample_batch fixture to include old_log_probs
- Update compute_advantages tests for tuple return value
- Add compute_advantages_zero_variance_masking test
- Update all edge case tests to include old_log_probs
- Update masked_group_ratio assertion in compute_loss tests
- Fix test_uniform_rewards_in_group to verify masking behavior