### PR TITLE
Add comprehensive test coverage for utils modules and fix import error

### DIFF
--- a/tests/test_utils/test_agent.py
+++ b/tests/test_utils/test_agent.py
@@ -1,0 +1,403 @@
+"""
+Test Suite for ThinkRL Agent Utilities
+======================================
+
+Tests for:
+- thinkrl.utils.agent (AgentState, AgentInstanceBase, AgentExecutorBase, etc.)
+"""
+
+import asyncio
+import logging
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from thinkrl.utils.agent import (
+    AgentExecutorBase,
+    AgentInstanceBase,
+    AgentState,
+    load_agent_class,
+    create_agent_remote,
+    _RAY_AVAILABLE,
+    _VLLM_AVAILABLE,
+)
+
+
+class TestAgentState:
+    """Tests for AgentState dataclass."""
+
+    def test_default_initialization(self):
+        """Test default values of AgentState."""
+        state = AgentState()
+        assert state.input_ids == []
+        assert state.attention_mask == []
+        assert state.action_positions == []
+        assert state.observations == []
+        assert state.actions == []
+        assert state.rewards == []
+        assert state.log_probs == []
+        assert state.done is False
+        assert state.step_count == 0
+        assert state.metadata == {}
+
+    def test_custom_initialization(self):
+        """Test AgentState with custom values."""
+        state = AgentState(
+            input_ids=[1, 2, 3],
+            attention_mask=[1, 1, 1],
+            action_positions=[(0, 3)],
+            observations=["obs1"],
+            actions=["action1"],
+            rewards=[0.5],
+            log_probs=[-0.1],
+            done=True,
+            step_count=1,
+            metadata={"key": "value"},
+        )
+        assert state.input_ids == [1, 2, 3]
+        assert state.done is True
+        assert state.step_count == 1
+        assert state.metadata["key"] == "value"
+
+    def test_state_mutability(self):
+        """Test that AgentState can be mutated."""
+        state = AgentState()
+        state.input_ids.append(1)
+        state.done = True
+        state.step_count = 5
+
+        assert state.input_ids == [1]
+        assert state.done is True
+        assert state.step_count == 5
+
+
+class ConcreteAgent(AgentInstanceBase):
+    """Concrete implementation for testing."""
+
+    def __init__(self, env_name: str = "test"):
+        self.env_name = env_name
+        self.step_count = 0
+
+    def step(self, state_dict):
+        self.step_count += 1
+        return {
+            "observation": f"obs_{self.step_count}",
+            "reward": 0.5,
+            "done": self.step_count >= 3,
+        }
+
+    def reset(self, states, **kwargs):
+        self.step_count = 0
+        states["reset"] = True
+        return states
+
+
+class TestAgentInstanceBase:
+    """Tests for AgentInstanceBase abstract class."""
+
+    def test_concrete_agent_init(self):
+        """Test initialization of concrete agent."""
+        agent = ConcreteAgent(env_name="my_env")
+        assert agent.env_name == "my_env"
+
+    def test_concrete_agent_step(self):
+        """Test step method of concrete agent."""
+        agent = ConcreteAgent()
+        result = agent.step({"input_ids": [1, 2, 3]})
+
+        assert "observation" in result
+        assert "reward" in result
+        assert "done" in result
+        assert result["reward"] == 0.5
+        assert agent.step_count == 1
+
+    def test_concrete_agent_reset(self):
+        """Test reset method of concrete agent."""
+        agent = ConcreteAgent()
+        agent.step({})
+        agent.step({})
+
+        assert agent.step_count == 2
+
+        states = {"input_ids": [1]}
+        result = agent.reset(states)
+
+        assert agent.step_count == 0
+        assert result["reset"] is True
+
+    def test_base_reset_default(self):
+        """Test that base class reset returns states unchanged."""
+        # Create a minimal subclass that doesn't override reset
+        class MinimalAgent(AgentInstanceBase):
+            def __init__(self):
+                pass
+            def step(self, state_dict, **kwargs):
+                return {}
+
+        agent = MinimalAgent()
+        states = {"test": "value"}
+        result = agent.reset(states)
+        assert result == states
+
+
+class TestAgentExecutorBase:
+    """Tests for AgentExecutorBase."""
+
+    @pytest.fixture
+    def mock_tokenizer(self):
+        """Create a mock tokenizer."""
+        tokenizer = MagicMock()
+        tokenizer.encode.return_value = [1, 2, 3]
+        tokenizer.decode.return_value = "decoded text"
+        return tokenizer
+
+    @pytest.fixture
+    def mock_llm_engine(self):
+        """Create a mock LLM engine."""
+        return MagicMock()
+
+    def test_executor_init(self, mock_llm_engine, mock_tokenizer):
+        """Test executor initialization."""
+        executor = AgentExecutorBase(
+            llm_engine=mock_llm_engine,
+            tokenizer=mock_tokenizer,
+            agent_class=ConcreteAgent,
+            max_steps=5,
+            max_length=1024,
+            max_concurrent=64,
+            compute_log_probs=True,
+        )
+
+        assert executor.llm_engine is mock_llm_engine
+        assert executor.tokenizer is mock_tokenizer
+        assert executor.agent_class is ConcreteAgent
+        assert executor.max_steps == 5
+        assert executor.max_length == 1024
+        assert executor.compute_log_probs is True
+
+    def test_executor_init_defaults(self, mock_llm_engine, mock_tokenizer):
+        """Test executor initialization with defaults."""
+        executor = AgentExecutorBase(
+            llm_engine=mock_llm_engine,
+            tokenizer=mock_tokenizer,
+        )
+
+        assert executor.agent_class is None
+        assert executor.max_steps == 10
+        assert executor.max_length == 2048
+
+    @pytest.mark.skipif(not _VLLM_AVAILABLE, reason="vLLM not available")
+    @pytest.mark.asyncio
+    async def test_generate_requires_vllm(self, mock_llm_engine, mock_tokenizer):
+        """Test that generate works when vLLM is available."""
+        executor = AgentExecutorBase(
+            llm_engine=mock_llm_engine,
+            tokenizer=mock_tokenizer,
+        )
+        # This test would require vLLM to be installed
+
+    @pytest.mark.asyncio
+    async def test_generate_without_vllm(self, mock_llm_engine, mock_tokenizer):
+        """Test that generate raises error without vLLM."""
+        with patch("thinkrl.utils.agent._VLLM_AVAILABLE", False):
+            executor = AgentExecutorBase(
+                llm_engine=mock_llm_engine,
+                tokenizer=mock_tokenizer,
+            )
+
+            with pytest.raises(RuntimeError, match="vLLM is required"):
+                await executor.generate([1, 2, 3], MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_execute_with_string_prompt(self, mock_llm_engine, mock_tokenizer):
+        """Test execute with string prompt."""
+        with patch("thinkrl.utils.agent._VLLM_AVAILABLE", True):
+            with patch.object(AgentExecutorBase, "generate") as mock_generate:
+                mock_generate.return_value = {
+                    "output_ids": [4, 5],
+                    "text": "response",
+                    "log_probs": [],
+                }
+
+                executor = AgentExecutorBase(
+                    llm_engine=mock_llm_engine,
+                    tokenizer=mock_tokenizer,
+                    max_steps=1,
+                )
+
+                state = await executor.execute("test prompt", MagicMock())
+
+                assert isinstance(state, AgentState)
+                mock_tokenizer.encode.assert_called_with("test prompt")
+
+    @pytest.mark.asyncio
+    async def test_execute_with_token_prompt(self, mock_llm_engine, mock_tokenizer):
+        """Test execute with token list prompt."""
+        with patch("thinkrl.utils.agent._VLLM_AVAILABLE", True):
+            with patch.object(AgentExecutorBase, "generate") as mock_generate:
+                mock_generate.return_value = {
+                    "output_ids": [4, 5],
+                    "text": "response",
+                    "log_probs": [-0.1, -0.2],
+                }
+
+                executor = AgentExecutorBase(
+                    llm_engine=mock_llm_engine,
+                    tokenizer=mock_tokenizer,
+                    max_steps=1,
+                    compute_log_probs=True,
+                )
+
+                state = await executor.execute([1, 2, 3], MagicMock())
+
+                assert isinstance(state, AgentState)
+                assert state.input_ids == [1, 2, 3, 4, 5]
+
+    @pytest.mark.asyncio
+    async def test_execute_with_agent_no_ray(self, mock_llm_engine, mock_tokenizer):
+        """Test execute with agent class without Ray."""
+        with patch("thinkrl.utils.agent._VLLM_AVAILABLE", True):
+            with patch("thinkrl.utils.agent._RAY_AVAILABLE", False):
+                with patch.object(AgentExecutorBase, "generate") as mock_generate:
+                    mock_generate.return_value = {
+                        "output_ids": [4],
+                        "text": "action",
+                        "log_probs": [],
+                    }
+
+                    executor = AgentExecutorBase(
+                        llm_engine=mock_llm_engine,
+                        tokenizer=mock_tokenizer,
+                        agent_class=ConcreteAgent,
+                        max_steps=2,
+                    )
+
+                    state = await executor.execute([1, 2, 3], MagicMock())
+
+                    assert isinstance(state, AgentState)
+                    assert len(state.observations) > 0
+
+    @pytest.mark.asyncio
+    async def test_run_batch(self, mock_llm_engine, mock_tokenizer):
+        """Test batch execution."""
+        with patch.object(AgentExecutorBase, "execute") as mock_execute:
+            mock_execute.return_value = AgentState()
+
+            executor = AgentExecutorBase(
+                llm_engine=mock_llm_engine,
+                tokenizer=mock_tokenizer,
+            )
+
+            results = await executor.run_batch(
+                prompts=["prompt1", "prompt2"],
+                sampling_params=MagicMock(),
+            )
+
+            assert len(results) == 2
+            assert mock_execute.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_run_batch_with_kwargs(self, mock_llm_engine, mock_tokenizer):
+        """Test batch execution with agent kwargs."""
+        with patch.object(AgentExecutorBase, "execute") as mock_execute:
+            mock_execute.return_value = AgentState()
+
+            executor = AgentExecutorBase(
+                llm_engine=mock_llm_engine,
+                tokenizer=mock_tokenizer,
+            )
+
+            results = await executor.run_batch(
+                prompts=["prompt1", "prompt2"],
+                sampling_params=MagicMock(),
+                agent_kwargs_list=[{"env": "env1"}, {"env": "env2"}],
+            )
+
+            assert len(results) == 2
+
+
+class TestLoadAgentClass:
+    """Tests for load_agent_class function."""
+
+    @pytest.fixture
+    def temp_agent_file(self):
+        """Create a temporary Python file with an agent class."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("""
+from thinkrl.utils.agent import AgentInstanceBase
+
+class TestAgentFromFile(AgentInstanceBase):
+    def __init__(self, config=None):
+        self.config = config
+
+    def step(self, state_dict, **kwargs):
+        return {"observation": "obs", "reward": 1.0, "done": True}
+""")
+            f.flush()
+            yield f.name
+        os.unlink(f.name)
+
+    @pytest.fixture
+    def temp_agent_file_not_subclass(self):
+        """Create a temp file with a non-subclass agent."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("""
+class NotAnAgent:
+    def __init__(self):
+        pass
+
+    def step(self, state_dict):
+        return {}
+""")
+            f.flush()
+            yield f.name
+        os.unlink(f.name)
+
+    def test_load_agent_class_success(self, temp_agent_file):
+        """Test loading agent class from file."""
+        AgentClass = load_agent_class(temp_agent_file, "TestAgentFromFile")
+
+        assert AgentClass is not None
+        assert AgentClass.__name__ == "TestAgentFromFile"
+
+        # Test instantiation
+        agent = AgentClass(config={"key": "value"})
+        assert agent.config == {"key": "value"}
+
+    def test_load_agent_class_file_not_found(self):
+        """Test error when file doesn't exist."""
+        with pytest.raises(FileNotFoundError):
+            load_agent_class("/nonexistent/path.py", "Agent")
+
+    def test_load_agent_class_class_not_found(self, temp_agent_file):
+        """Test error when class doesn't exist in file."""
+        with pytest.raises(AttributeError, match="not found"):
+            load_agent_class(temp_agent_file, "NonexistentClass")
+
+    def test_load_agent_class_not_subclass_warning(self, temp_agent_file_not_subclass, caplog):
+        """Test warning when class is not a subclass of AgentInstanceBase."""
+        with caplog.at_level(logging.WARNING):
+            AgentClass = load_agent_class(temp_agent_file_not_subclass, "NotAnAgent")
+
+        assert AgentClass is not None
+        assert "does not inherit from AgentInstanceBase" in caplog.text
+
+
+class TestCreateAgentRemote:
+    """Tests for create_agent_remote function."""
+
+    def test_create_agent_remote_without_ray(self):
+        """Test that create_agent_remote raises error without Ray."""
+        with patch("thinkrl.utils.agent._RAY_AVAILABLE", False):
+            # Need to reload or patch at module level
+            with pytest.raises(RuntimeError, match="Ray is required"):
+                create_agent_remote(ConcreteAgent)
+
+    @pytest.mark.skipif(not _RAY_AVAILABLE, reason="Ray not available")
+    def test_create_agent_remote_with_ray(self):
+        """Test creating remote agent with Ray."""
+        RemoteAgent = create_agent_remote(ConcreteAgent, num_cpus=0.5, num_gpus=0.0)
+        assert RemoteAgent is not None

--- a/tests/test_utils/test_agent.py
+++ b/tests/test_utils/test_agent.py
@@ -133,7 +133,7 @@ class TestAgentInstanceBase:
         # Create a minimal subclass that doesn't override reset
         class MinimalAgent(AgentInstanceBase):
             def __init__(self):
-                pass
+                super().__init__()
             def step(self, state_dict, **kwargs):
                 return {}
 

--- a/tests/test_utils/test_agent.py
+++ b/tests/test_utils/test_agent.py
@@ -6,12 +6,10 @@ Tests for:
 - thinkrl.utils.agent (AgentState, AgentInstanceBase, AgentExecutorBase, etc.)
 """
 
-import asyncio
 import logging
 import os
 import tempfile
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -78,6 +76,7 @@ class ConcreteAgent(AgentInstanceBase):
     """Concrete implementation for testing."""
 
     def __init__(self, env_name: str = "test"):
+        super().__init__()
         self.env_name = env_name
         self.step_count = 0
 

--- a/tests/test_utils/test_checkpoint.py
+++ b/tests/test_utils/test_checkpoint.py
@@ -192,3 +192,103 @@ class TestStandaloneFunctions:
         loaded = load_config(path)
 
         assert loaded == config
+
+
+class TestCheckpointEdgeCases:
+    """Test edge cases and additional functionality."""
+
+    def test_load_checkpoint_with_optimizer(self, temp_dir, simple_model, simple_optimizer):
+        """Test loading checkpoint with optimizer state."""
+        path = temp_dir / "checkpoint_with_opt.pt"
+
+        save_checkpoint(path, simple_model, optimizer=simple_optimizer, epoch=5)
+
+        loaded_metadata = load_checkpoint(path, simple_model, optimizer=simple_optimizer)
+        assert loaded_metadata["epoch"] == 5
+
+    def test_checkpoint_manager_auto_naming(self, temp_dir, simple_model):
+        """Test automatic checkpoint naming."""
+        manager = CheckpointManager(checkpoint_dir=temp_dir)
+
+        manager.save_checkpoint(simple_model, epoch=1)
+
+        # Should create a checkpoint with auto-generated name
+        checkpoints = list(temp_dir.glob("*"))
+        assert len(checkpoints) >= 1
+
+    def test_checkpoint_manager_load_latest(self, temp_dir, simple_model):
+        """Test loading the latest checkpoint."""
+        manager = CheckpointManager(checkpoint_dir=temp_dir)
+
+        manager.save_checkpoint(simple_model, epoch=1, checkpoint_name="ckpt_1")
+        manager.save_checkpoint(simple_model, epoch=2, checkpoint_name="ckpt_2")
+
+        metadata = manager.load_latest_checkpoint(simple_model)
+        assert metadata is not None
+        assert metadata["epoch"] == 2
+
+    def test_checkpoint_manager_no_checkpoints(self, temp_dir, simple_model):
+        """Test loading when no checkpoints exist."""
+        manager = CheckpointManager(checkpoint_dir=temp_dir)
+
+        metadata = manager.load_latest_checkpoint(simple_model)
+        assert metadata is None
+
+    def test_checkpoint_manager_metrics_only(self, temp_dir, simple_model):
+        """Test saving checkpoint with metrics only."""
+        manager = CheckpointManager(checkpoint_dir=temp_dir)
+
+        manager.save_checkpoint(
+            simple_model,
+            epoch=1,
+            metrics={"loss": 0.5, "accuracy": 0.9},
+            checkpoint_name="metrics_test",
+        )
+
+        loaded = manager.load_checkpoint(temp_dir / "metrics_test", simple_model)
+        assert loaded["metrics"]["loss"] == 0.5
+        assert loaded["metrics"]["accuracy"] == 0.9
+
+    def test_save_checkpoint_with_extra_state(self, temp_dir, simple_model):
+        """Test saving checkpoint with extra state dictionary."""
+        path = temp_dir / "extra_state.pt"
+
+        extra_state = {"custom_key": "custom_value", "step": 100}
+        save_checkpoint(path, simple_model, epoch=1, extra_state=extra_state)
+
+        loaded = load_checkpoint(path, simple_model)
+        assert loaded.get("custom_key") == "custom_value"
+        assert loaded.get("step") == 100
+
+    def test_checkpoint_manager_mode_max(self, temp_dir, simple_model):
+        """Test checkpoint manager with max mode."""
+        manager = CheckpointManager(
+            checkpoint_dir=temp_dir,
+            max_checkpoints=2,
+            metric_name="accuracy",
+            mode="max",
+        )
+
+        manager.save_checkpoint(simple_model, epoch=1, metrics={"accuracy": 0.7}, checkpoint_name="ckpt_1")
+        manager.save_checkpoint(simple_model, epoch=2, metrics={"accuracy": 0.9}, checkpoint_name="ckpt_2")
+        manager.save_checkpoint(simple_model, epoch=3, metrics={"accuracy": 0.8}, checkpoint_name="ckpt_3")
+
+        # Best should be ckpt_2 with accuracy 0.9
+        assert manager.best_checkpoint["name"] == "ckpt_2"
+        assert manager.best_checkpoint["metrics"]["accuracy"] == 0.9
+
+    def test_load_config_unsupported_format(self, temp_dir):
+        """Test loading config with unsupported format."""
+        path = temp_dir / "config.xyz"
+        path.write_text("some content")
+
+        with pytest.raises(ValueError, match="Unsupported config format"):
+            load_config(path)
+
+    def test_save_config_unsupported_format(self, temp_dir):
+        """Test saving config with unsupported format."""
+        config = {"key": "value"}
+        path = temp_dir / "config.xyz"
+
+        with pytest.raises(ValueError, match="Unsupported config format"):
+            save_config(config, path)

--- a/tests/test_utils/test_data.py
+++ b/tests/test_utils/test_data.py
@@ -244,3 +244,214 @@ def test_prepare_batch_for_training():
     with patch("thinkrl.utils.datasets.to_device") as mock_to:
         prepare_batch_for_training({}, "cpu")
         mock_to.assert_called_once()
+
+
+class TestZeroPadSequences:
+    """Tests for zero_pad_sequences function."""
+
+    def test_zero_pad_left(self):
+        from thinkrl.utils.datasets import zero_pad_sequences
+
+        seqs = [torch.tensor([1, 2]), torch.tensor([3, 4, 5])]
+        padded = zero_pad_sequences(seqs, side="left", value=0)
+
+        expected = torch.tensor([[0, 1, 2], [3, 4, 5]])
+        assert torch.equal(padded, expected)
+
+    def test_zero_pad_right(self):
+        from thinkrl.utils.datasets import zero_pad_sequences
+
+        seqs = [torch.tensor([1, 2]), torch.tensor([3, 4, 5])]
+        padded = zero_pad_sequences(seqs, side="right", value=0)
+
+        expected = torch.tensor([[1, 2, 0], [3, 4, 5]])
+        assert torch.equal(padded, expected)
+
+    def test_zero_pad_custom_value(self):
+        from thinkrl.utils.datasets import zero_pad_sequences
+
+        seqs = [torch.tensor([1, 2]), torch.tensor([3, 4, 5])]
+        padded = zero_pad_sequences(seqs, side="left", value=-1)
+
+        expected = torch.tensor([[-1, 1, 2], [3, 4, 5]])
+        assert torch.equal(padded, expected)
+
+    def test_zero_pad_empty(self):
+        from thinkrl.utils.datasets import zero_pad_sequences
+
+        result = zero_pad_sequences([])
+        assert torch.equal(result, torch.tensor([]))
+
+    def test_zero_pad_no_padding_needed(self):
+        from thinkrl.utils.datasets import zero_pad_sequences
+
+        seqs = [torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6])]
+        padded = zero_pad_sequences(seqs, side="left")
+
+        expected = torch.tensor([[1, 2, 3], [4, 5, 6]])
+        assert torch.equal(padded, expected)
+
+    def test_zero_pad_stack(self):
+        from thinkrl.utils.datasets import zero_pad_sequences
+
+        seqs = [torch.tensor([1, 2]), torch.tensor([3, 4, 5])]
+        padded = zero_pad_sequences(seqs, side="left", stack=True)
+
+        assert padded.shape == (2, 3)
+
+
+class TestRemovePadToken:
+    """Tests for remove_pad_token function."""
+
+    def test_remove_left_padding(self):
+        from thinkrl.utils.datasets import remove_pad_token
+
+        input_ids = torch.tensor([[0, 0, 1, 2], [3, 4, 5, 6]])
+        attention_mask = torch.tensor([[0, 0, 1, 1], [1, 1, 1, 1]])
+
+        unpadded = remove_pad_token(input_ids, attention_mask)
+
+        assert len(unpadded) == 2
+        assert torch.equal(unpadded[0], torch.tensor([1, 2]))
+        assert torch.equal(unpadded[1], torch.tensor([3, 4, 5, 6]))
+
+    def test_remove_right_padding(self):
+        from thinkrl.utils.datasets import remove_pad_token
+
+        input_ids = torch.tensor([[1, 2, 0, 0], [3, 4, 5, 0]])
+        attention_mask = torch.tensor([[1, 1, 0, 0], [1, 1, 1, 0]])
+
+        unpadded = remove_pad_token(input_ids, attention_mask)
+
+        assert len(unpadded) == 2
+        assert torch.equal(unpadded[0], torch.tensor([1, 2]))
+        assert torch.equal(unpadded[1], torch.tensor([3, 4, 5]))
+
+    def test_remove_no_padding(self):
+        from thinkrl.utils.datasets import remove_pad_token
+
+        input_ids = torch.tensor([[1, 2, 3]])
+        attention_mask = torch.tensor([[1, 1, 1]])
+
+        unpadded = remove_pad_token(input_ids, attention_mask)
+
+        assert len(unpadded) == 1
+        assert torch.equal(unpadded[0], torch.tensor([1, 2, 3]))
+
+
+class TestConvertTokenToId:
+    """Tests for convert_token_to_id function."""
+
+    def test_convert_single_token(self):
+        from thinkrl.utils.datasets import convert_token_to_id
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.encode.return_value = [42]
+
+        result = convert_token_to_id("<|endoftext|>", mock_tokenizer)
+
+        assert result == 42
+        mock_tokenizer.encode.assert_called_with("<|endoftext|>", add_special_tokens=False)
+
+    def test_convert_multi_token_raises_error(self):
+        from thinkrl.utils.datasets import convert_token_to_id
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.encode.return_value = [1, 2, 3]  # Token encodes to 3 tokens
+
+        with pytest.raises(ValueError, match="encodes to 3 tokens"):
+            convert_token_to_id("multi word token", mock_tokenizer)
+
+
+class TestGetStrategy:
+    """Tests for get_strategy function."""
+
+    def test_get_strategy_import_error(self):
+        from thinkrl.utils.datasets import get_strategy
+
+        # Should return None when import fails
+        result = get_strategy(MagicMock())
+        # This might return None or a strategy depending on the setup
+        assert result is None or result is not None  # Just verify no crash
+
+
+class TestApplyChatTemplate:
+    """Tests for apply_chat_template function."""
+
+    def test_apply_chat_template_with_tokenizer_support(self):
+        from thinkrl.utils.datasets import apply_chat_template
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "Formatted chat"
+
+        messages = [
+            {"role": "user", "content": "Hello!"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+
+        result = apply_chat_template(messages, mock_tokenizer)
+
+        assert result == "Formatted chat"
+        mock_tokenizer.apply_chat_template.assert_called_with(
+            messages,
+            add_generation_prompt=False,
+            tokenize=False,
+        )
+
+    def test_apply_chat_template_with_generation_prompt(self):
+        from thinkrl.utils.datasets import apply_chat_template
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "Chat with prompt"
+
+        messages = [{"role": "user", "content": "Hello!"}]
+
+        result = apply_chat_template(messages, mock_tokenizer, add_generation_prompt=True)
+
+        mock_tokenizer.apply_chat_template.assert_called_with(
+            messages,
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+
+    def test_apply_chat_template_fallback(self):
+        from thinkrl.utils.datasets import apply_chat_template
+
+        # Tokenizer without apply_chat_template
+        mock_tokenizer = MagicMock(spec=[])
+        del mock_tokenizer.apply_chat_template  # Ensure it doesn't exist
+
+        messages = [
+            {"role": "user", "content": "Hello!"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+
+        result = apply_chat_template(messages, mock_tokenizer)
+
+        assert "User: Hello!" in result
+        assert "Assistant: Hi!" in result
+
+    def test_apply_chat_template_fallback_with_generation_prompt(self):
+        from thinkrl.utils.datasets import apply_chat_template
+
+        mock_tokenizer = MagicMock(spec=[])
+        del mock_tokenizer.apply_chat_template
+
+        messages = [{"role": "user", "content": "Hello!"}]
+
+        result = apply_chat_template(messages, mock_tokenizer, add_generation_prompt=True)
+
+        assert result.endswith("Assistant:")
+
+    def test_apply_chat_template_fallback_tokenize(self):
+        from thinkrl.utils.datasets import apply_chat_template
+
+        mock_tokenizer = MagicMock(spec=["__call__"])
+        mock_tokenizer.return_value = {"input_ids": [1, 2, 3]}
+
+        messages = [{"role": "user", "content": "Hello!"}]
+
+        result = apply_chat_template(messages, mock_tokenizer, tokenize=True)
+
+        mock_tokenizer.assert_called()
+        assert result == {"input_ids": [1, 2, 3]}

--- a/tests/test_utils/test_distributed_sampler.py
+++ b/tests/test_utils/test_distributed_sampler.py
@@ -1,0 +1,493 @@
+"""
+Test Suite for ThinkRL Distributed Sampler Utilities
+====================================================
+
+Tests for:
+- DistributedSampler
+- DistributedBatchSampler
+- SequentialDistributedSampler
+"""
+
+import math
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from torch.utils.data import Dataset
+
+from thinkrl.utils.distributed_sampler import (
+    DistributedSampler,
+    DistributedBatchSampler,
+    SequentialDistributedSampler,
+)
+
+
+class SimpleDataset(Dataset):
+    """Simple dataset for testing."""
+
+    def __init__(self, size: int = 100):
+        self.size = size
+        self.data = list(range(size))
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+
+class TestDistributedSampler:
+    """Tests for DistributedSampler class."""
+
+    @pytest.fixture
+    def dataset(self):
+        return SimpleDataset(100)
+
+    @pytest.fixture
+    def small_dataset(self):
+        return SimpleDataset(10)
+
+    def test_init_basic(self, dataset):
+        """Test basic initialization."""
+        sampler = DistributedSampler(
+            dataset=dataset,
+            num_replicas=4,
+            rank=0,
+            shuffle=True,
+            seed=42,
+        )
+
+        assert sampler.dataset is dataset
+        assert sampler.num_replicas == 4
+        assert sampler.rank == 0
+        assert sampler.shuffle is True
+        assert sampler.seed == 42
+        assert sampler.consumed_samples == 0
+
+    def test_init_with_consumed_samples(self, dataset):
+        """Test initialization with consumed samples."""
+        sampler = DistributedSampler(
+            dataset=dataset,
+            num_replicas=2,
+            rank=0,
+            consumed_samples=20,
+        )
+
+        assert sampler.consumed_samples == 20
+
+    def test_init_invalid_rank(self, dataset):
+        """Test initialization with invalid rank raises error."""
+        with pytest.raises(ValueError, match="Invalid rank"):
+            DistributedSampler(
+                dataset=dataset,
+                num_replicas=4,
+                rank=4,  # Invalid: should be 0-3
+            )
+
+        with pytest.raises(ValueError, match="Invalid rank"):
+            DistributedSampler(
+                dataset=dataset,
+                num_replicas=4,
+                rank=-1,
+            )
+
+    def test_init_auto_rank_not_initialized(self, dataset):
+        """Test auto rank detection when dist is not initialized."""
+        with patch("torch.distributed.is_available", return_value=True):
+            with patch("torch.distributed.is_initialized", return_value=False):
+                sampler = DistributedSampler(dataset=dataset)
+                assert sampler.num_replicas == 1
+                assert sampler.rank == 0
+
+    def test_iter_shuffled(self, dataset):
+        """Test iterator with shuffling."""
+        sampler = DistributedSampler(
+            dataset=dataset,
+            num_replicas=4,
+            rank=0,
+            shuffle=True,
+            seed=42,
+        )
+
+        indices = list(sampler)
+
+        # Should have approximately 25 samples (100 / 4)
+        assert len(indices) == 25
+
+        # All indices should be valid
+        assert all(0 <= idx < 100 for idx in indices)
+
+    def test_iter_not_shuffled(self, dataset):
+        """Test iterator without shuffling."""
+        sampler = DistributedSampler(
+            dataset=dataset,
+            num_replicas=4,
+            rank=0,
+            shuffle=False,
+        )
+
+        indices = list(sampler)
+        assert len(indices) == 25
+
+        # Indices should be deterministic (strided)
+        expected = list(range(0, 100, 4))
+        assert indices == expected
+
+    def test_iter_different_ranks(self, dataset):
+        """Test that different ranks get different indices."""
+        samplers = [
+            DistributedSampler(
+                dataset=dataset,
+                num_replicas=4,
+                rank=i,
+                shuffle=False,
+            )
+            for i in range(4)
+        ]
+
+        all_indices = [list(s) for s in samplers]
+
+        # Each rank should have same number of samples
+        assert all(len(idx) == 25 for idx in all_indices)
+
+        # No overlap between ranks
+        for i in range(4):
+            for j in range(i + 1, 4):
+                assert set(all_indices[i]).isdisjoint(set(all_indices[j]))
+
+    def test_iter_with_consumed_samples(self, dataset):
+        """Test that consumed samples are skipped."""
+        sampler = DistributedSampler(
+            dataset=dataset,
+            num_replicas=2,
+            rank=0,
+            shuffle=False,
+            consumed_samples=20,  # 10 per replica
+        )
+
+        indices = list(sampler)
+
+        # Should skip 10 samples per replica
+        assert len(indices) == 40  # 50 - 10
+
+    def test_iter_drop_last(self, small_dataset):
+        """Test drop_last functionality."""
+        sampler = DistributedSampler(
+            dataset=small_dataset,
+            num_replicas=3,
+            rank=0,
+            shuffle=False,
+            drop_last=True,
+        )
+
+        indices = list(sampler)
+        # With drop_last, should truncate to evenly divisible
+        assert len(indices) == 3
+
+    def test_len_basic(self, dataset):
+        """Test length calculation."""
+        sampler = DistributedSampler(
+            dataset=dataset,
+            num_replicas=4,
+            rank=0,
+        )
+
+        assert len(sampler) == 25
+
+    def test_len_with_consumed(self, dataset):
+        """Test length with consumed samples."""
+        sampler = DistributedSampler(
+            dataset=dataset,
+            num_replicas=4,
+            rank=0,
+            consumed_samples=40,  # 10 per replica
+        )
+
+        assert len(sampler) == 15  # 25 - 10
+
+    def test_set_epoch(self, dataset):
+        """Test set_epoch method."""
+        sampler = DistributedSampler(
+            dataset=dataset,
+            num_replicas=4,
+            rank=0,
+            shuffle=True,
+        )
+
+        # Get indices for epoch 0
+        indices_epoch0 = list(sampler)
+
+        # Set epoch 1 and get new indices
+        sampler.set_epoch(1)
+        indices_epoch1 = list(sampler)
+
+        # Different epochs should produce different orderings
+        assert indices_epoch0 != indices_epoch1
+
+    def test_set_epoch_with_consumed(self, dataset):
+        """Test set_epoch with consumed samples."""
+        sampler = DistributedSampler(
+            dataset=dataset,
+            num_replicas=2,
+            rank=0,
+        )
+
+        sampler.set_epoch(5, consumed_samples=30)
+
+        assert sampler.epoch == 5
+        assert sampler.consumed_samples == 30
+
+    def test_reproducibility(self, dataset):
+        """Test that same seed produces same results."""
+        sampler1 = DistributedSampler(
+            dataset=dataset,
+            num_replicas=4,
+            rank=0,
+            shuffle=True,
+            seed=123,
+        )
+
+        sampler2 = DistributedSampler(
+            dataset=dataset,
+            num_replicas=4,
+            rank=0,
+            shuffle=True,
+            seed=123,
+        )
+
+        assert list(sampler1) == list(sampler2)
+
+
+class TestDistributedBatchSampler:
+    """Tests for DistributedBatchSampler class."""
+
+    @pytest.fixture
+    def base_sampler(self):
+        dataset = SimpleDataset(100)
+        return DistributedSampler(
+            dataset=dataset,
+            num_replicas=2,
+            rank=0,
+            shuffle=False,
+        )
+
+    def test_init_basic(self, base_sampler):
+        """Test basic initialization."""
+        batch_sampler = DistributedBatchSampler(
+            sampler=base_sampler,
+            batch_size=10,
+            drop_last=False,
+        )
+
+        assert batch_sampler.sampler is base_sampler
+        assert batch_sampler.batch_size == 10
+        assert batch_sampler.drop_last is False
+        assert batch_sampler.consumed_batches == 0
+
+    def test_init_invalid_batch_size(self, base_sampler):
+        """Test that invalid batch size raises error."""
+        with pytest.raises(ValueError, match="positive integer"):
+            DistributedBatchSampler(
+                sampler=base_sampler,
+                batch_size=0,
+            )
+
+        with pytest.raises(ValueError, match="positive integer"):
+            DistributedBatchSampler(
+                sampler=base_sampler,
+                batch_size=-1,
+            )
+
+    def test_iter_batches(self, base_sampler):
+        """Test iteration over batches."""
+        batch_sampler = DistributedBatchSampler(
+            sampler=base_sampler,
+            batch_size=10,
+            drop_last=False,
+        )
+
+        batches = list(batch_sampler)
+
+        # 50 samples / 10 per batch = 5 batches
+        assert len(batches) == 5
+        assert all(len(batch) == 10 for batch in batches)
+
+    def test_iter_drop_last(self, base_sampler):
+        """Test drop_last functionality."""
+        batch_sampler = DistributedBatchSampler(
+            sampler=base_sampler,
+            batch_size=15,
+            drop_last=True,
+        )
+
+        batches = list(batch_sampler)
+
+        # 50 samples / 15 = 3 full batches (drop remaining 5)
+        assert len(batches) == 3
+        assert all(len(batch) == 15 for batch in batches)
+
+    def test_iter_with_consumed_batches(self, base_sampler):
+        """Test skipping consumed batches."""
+        batch_sampler = DistributedBatchSampler(
+            sampler=base_sampler,
+            batch_size=10,
+            drop_last=False,
+            consumed_batches=2,
+        )
+
+        batches = list(batch_sampler)
+
+        # 5 batches total - 2 consumed = 3 remaining
+        assert len(batches) == 3
+
+    def test_len_basic(self, base_sampler):
+        """Test length calculation."""
+        batch_sampler = DistributedBatchSampler(
+            sampler=base_sampler,
+            batch_size=10,
+            drop_last=False,
+        )
+
+        assert len(batch_sampler) == 5
+
+    def test_len_drop_last(self, base_sampler):
+        """Test length with drop_last."""
+        batch_sampler = DistributedBatchSampler(
+            sampler=base_sampler,
+            batch_size=15,
+            drop_last=True,
+        )
+
+        assert len(batch_sampler) == 3
+
+    def test_len_with_consumed(self, base_sampler):
+        """Test length with consumed batches."""
+        batch_sampler = DistributedBatchSampler(
+            sampler=base_sampler,
+            batch_size=10,
+            consumed_batches=2,
+        )
+
+        assert len(batch_sampler) == 3
+
+    def test_set_consumed_batches(self, base_sampler):
+        """Test set_consumed_batches method."""
+        batch_sampler = DistributedBatchSampler(
+            sampler=base_sampler,
+            batch_size=10,
+        )
+
+        batch_sampler.set_consumed_batches(3)
+        assert batch_sampler.consumed_batches == 3
+        assert len(batch_sampler) == 2
+
+
+class TestSequentialDistributedSampler:
+    """Tests for SequentialDistributedSampler class."""
+
+    @pytest.fixture
+    def dataset(self):
+        return SimpleDataset(100)
+
+    @pytest.fixture
+    def small_dataset(self):
+        return SimpleDataset(10)
+
+    def test_init_basic(self, dataset):
+        """Test basic initialization."""
+        sampler = SequentialDistributedSampler(
+            dataset=dataset,
+            num_replicas=4,
+            rank=0,
+        )
+
+        assert sampler.dataset is dataset
+        assert sampler.num_replicas == 4
+        assert sampler.rank == 0
+
+    def test_init_auto_detection(self, dataset):
+        """Test auto detection of rank and world size."""
+        with patch("torch.distributed.is_available", return_value=True):
+            with patch("torch.distributed.is_initialized", return_value=False):
+                sampler = SequentialDistributedSampler(dataset=dataset)
+                assert sampler.num_replicas == 1
+                assert sampler.rank == 0
+
+    def test_iter_sequential_chunks(self, dataset):
+        """Test that indices are sequential chunks."""
+        samplers = [
+            SequentialDistributedSampler(
+                dataset=dataset,
+                num_replicas=4,
+                rank=i,
+            )
+            for i in range(4)
+        ]
+
+        all_indices = [list(s) for s in samplers]
+
+        # Rank 0 should get first 25, rank 1 next 25, etc.
+        assert all_indices[0] == list(range(0, 25))
+        assert all_indices[1] == list(range(25, 50))
+        assert all_indices[2] == list(range(50, 75))
+        assert all_indices[3] == list(range(75, 100))
+
+    def test_iter_with_padding(self, small_dataset):
+        """Test padding when dataset not evenly divisible."""
+        sampler = SequentialDistributedSampler(
+            dataset=small_dataset,
+            num_replicas=4,
+            rank=3,  # Last rank might get padded samples
+        )
+
+        indices = list(sampler)
+
+        # All indices should be valid (no padding indices returned)
+        assert all(0 <= idx < 10 for idx in indices)
+
+    def test_len_basic(self, dataset):
+        """Test length calculation."""
+        sampler = SequentialDistributedSampler(
+            dataset=dataset,
+            num_replicas=4,
+            rank=0,
+        )
+
+        assert len(sampler) == 25
+
+    def test_len_uneven(self, small_dataset):
+        """Test length with uneven division."""
+        # 10 samples / 4 replicas = 2-3 samples per replica
+        sampler0 = SequentialDistributedSampler(
+            dataset=small_dataset,
+            num_replicas=4,
+            rank=0,
+        )
+        sampler3 = SequentialDistributedSampler(
+            dataset=small_dataset,
+            num_replicas=4,
+            rank=3,
+        )
+
+        # First replica gets full chunk
+        assert len(sampler0) == 3
+        # Last replica gets remainder (might be less)
+        assert len(sampler3) == 1
+
+    def test_coverage(self, dataset):
+        """Test that all samples are covered exactly once."""
+        samplers = [
+            SequentialDistributedSampler(
+                dataset=dataset,
+                num_replicas=4,
+                rank=i,
+            )
+            for i in range(4)
+        ]
+
+        all_indices = []
+        for s in samplers:
+            all_indices.extend(list(s))
+
+        # All indices should be covered
+        assert sorted(all_indices) == list(range(100))

--- a/tests/test_utils/test_distributed_util.py
+++ b/tests/test_utils/test_distributed_util.py
@@ -1,0 +1,383 @@
+"""
+Test Suite for ThinkRL Distributed Utilities
+=============================================
+
+Tests for:
+- thinkrl.utils.distributed_util
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from thinkrl.utils.distributed_util import (
+    all_gather,
+    all_reduce,
+    barrier,
+    broadcast,
+    broadcast_object,
+    cleanup_distributed,
+    gather_object,
+    get_local_rank,
+    get_rank,
+    get_world_size,
+    init_distributed,
+    is_distributed,
+    is_main_process,
+    reduce_mean,
+    stateless_init_process_group,
+    torch_dist_barrier_and_cuda_sync,
+)
+
+
+class TestBasicDistributedInfo:
+    """Tests for basic distributed info functions."""
+
+    def test_get_rank_not_initialized(self):
+        """Test get_rank when dist is not initialized."""
+        with patch("torch.distributed.is_available", return_value=True):
+            with patch("torch.distributed.is_initialized", return_value=False):
+                assert get_rank() == 0
+
+    def test_get_rank_initialized(self):
+        """Test get_rank when dist is initialized."""
+        with patch("torch.distributed.is_available", return_value=True):
+            with patch("torch.distributed.is_initialized", return_value=True):
+                with patch("torch.distributed.get_rank", return_value=3):
+                    assert get_rank() == 3
+
+    def test_get_world_size_not_initialized(self):
+        """Test get_world_size when dist is not initialized."""
+        with patch("torch.distributed.is_available", return_value=True):
+            with patch("torch.distributed.is_initialized", return_value=False):
+                assert get_world_size() == 1
+
+    def test_get_world_size_initialized(self):
+        """Test get_world_size when dist is initialized."""
+        with patch("torch.distributed.is_available", return_value=True):
+            with patch("torch.distributed.is_initialized", return_value=True):
+                with patch("torch.distributed.get_world_size", return_value=4):
+                    assert get_world_size() == 4
+
+    def test_get_local_rank_default(self):
+        """Test get_local_rank with no env var."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert get_local_rank() == 0
+
+    def test_get_local_rank_from_env(self):
+        """Test get_local_rank from environment."""
+        with patch.dict(os.environ, {"LOCAL_RANK": "2"}):
+            assert get_local_rank() == 2
+
+    def test_is_main_process_true(self):
+        """Test is_main_process returns True for rank 0."""
+        with patch("thinkrl.utils.distributed_util.get_rank", return_value=0):
+            assert is_main_process() is True
+
+    def test_is_main_process_false(self):
+        """Test is_main_process returns False for non-zero rank."""
+        with patch("thinkrl.utils.distributed_util.get_rank", return_value=1):
+            assert is_main_process() is False
+
+    def test_is_distributed_true(self):
+        """Test is_distributed when initialized."""
+        with patch("torch.distributed.is_available", return_value=True):
+            with patch("torch.distributed.is_initialized", return_value=True):
+                assert is_distributed() is True
+
+    def test_is_distributed_false_not_available(self):
+        """Test is_distributed when not available."""
+        with patch("torch.distributed.is_available", return_value=False):
+            assert is_distributed() is False
+
+    def test_is_distributed_false_not_initialized(self):
+        """Test is_distributed when not initialized."""
+        with patch("torch.distributed.is_available", return_value=True):
+            with patch("torch.distributed.is_initialized", return_value=False):
+                assert is_distributed() is False
+
+
+class TestInitDistributed:
+    """Tests for init_distributed function."""
+
+    def test_init_already_initialized(self):
+        """Test init when already initialized returns True."""
+        with patch("torch.distributed.is_initialized", return_value=True):
+            result = init_distributed()
+            assert result is True
+
+    def test_init_single_process(self):
+        """Test init with world_size=1 skips initialization."""
+        with patch("torch.distributed.is_initialized", return_value=False):
+            result = init_distributed(world_size=1, rank=0)
+            assert result is False
+
+    def test_init_from_env_single_process(self):
+        """Test init reads from env and skips for single process."""
+        with patch("torch.distributed.is_initialized", return_value=False):
+            with patch.dict(os.environ, {"WORLD_SIZE": "1", "RANK": "0"}):
+                result = init_distributed()
+                assert result is False
+
+    def test_init_success(self):
+        """Test successful initialization."""
+        with patch("torch.distributed.is_initialized", return_value=False):
+            with patch("torch.distributed.init_process_group") as mock_init:
+                with patch("torch.cuda.is_available", return_value=False):
+                    with patch("thinkrl.utils.distributed_util.get_rank", return_value=0):
+                        with patch("thinkrl.utils.distributed_util.get_world_size", return_value=2):
+                            with patch.dict(os.environ, {"WORLD_SIZE": "2", "RANK": "0"}):
+                                result = init_distributed(backend="gloo")
+
+                                assert result is True
+                                mock_init.assert_called_once()
+
+    def test_init_with_init_method(self):
+        """Test initialization with custom init_method."""
+        with patch("torch.distributed.is_initialized", return_value=False):
+            with patch("torch.distributed.init_process_group") as mock_init:
+                with patch("torch.cuda.is_available", return_value=False):
+                    with patch("thinkrl.utils.distributed_util.get_rank", return_value=0):
+                        with patch("thinkrl.utils.distributed_util.get_world_size", return_value=2):
+                            result = init_distributed(
+                                backend="gloo",
+                                init_method="tcp://localhost:29500",
+                                world_size=2,
+                                rank=0,
+                            )
+
+                            assert result is True
+                            mock_init.assert_called_once_with(
+                                backend="gloo",
+                                init_method="tcp://localhost:29500",
+                                world_size=2,
+                                rank=0,
+                            )
+
+    def test_init_failure(self):
+        """Test initialization failure returns False."""
+        with patch("torch.distributed.is_initialized", return_value=False):
+            with patch("torch.distributed.init_process_group", side_effect=Exception("Init failed")):
+                with patch.dict(os.environ, {"WORLD_SIZE": "2", "RANK": "0"}):
+                    result = init_distributed()
+                    assert result is False
+
+
+class TestSynchronization:
+    """Tests for synchronization functions."""
+
+    def test_barrier_not_distributed(self):
+        """Test barrier is no-op when not distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=False):
+            # Should not raise
+            barrier()
+
+    def test_barrier_distributed(self):
+        """Test barrier calls dist.barrier when distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=True):
+            with patch("torch.distributed.barrier") as mock_barrier:
+                barrier()
+                mock_barrier.assert_called_once()
+
+    def test_torch_dist_barrier_and_cuda_sync(self):
+        """Test combined barrier and CUDA sync."""
+        with patch("torch.distributed.is_available", return_value=True):
+            with patch("torch.distributed.is_initialized", return_value=True):
+                with patch("torch.distributed.barrier") as mock_barrier:
+                    with patch("torch.cuda.is_available", return_value=True):
+                        with patch("torch.cuda.synchronize") as mock_sync:
+                            torch_dist_barrier_and_cuda_sync()
+
+                            mock_barrier.assert_called_once()
+                            mock_sync.assert_called_once()
+
+    def test_torch_dist_barrier_no_cuda(self):
+        """Test barrier without CUDA."""
+        with patch("torch.distributed.is_available", return_value=True):
+            with patch("torch.distributed.is_initialized", return_value=True):
+                with patch("torch.distributed.barrier") as mock_barrier:
+                    with patch("torch.cuda.is_available", return_value=False):
+                        torch_dist_barrier_and_cuda_sync()
+                        mock_barrier.assert_called_once()
+
+
+class TestCollectiveOperations:
+    """Tests for collective operations."""
+
+    def test_all_reduce_not_distributed(self):
+        """Test all_reduce returns tensor unchanged when not distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=False):
+            tensor = torch.tensor([1.0, 2.0, 3.0])
+            result = all_reduce(tensor)
+            assert torch.equal(result, tensor)
+
+    def test_all_reduce_distributed(self):
+        """Test all_reduce calls dist.all_reduce when distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=True):
+            with patch("torch.distributed.all_reduce") as mock_reduce:
+                tensor = torch.tensor([1.0, 2.0, 3.0])
+                result = all_reduce(tensor)
+
+                mock_reduce.assert_called_once()
+                assert result is tensor
+
+    def test_all_reduce_async(self):
+        """Test all_reduce with async_op=True."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=True):
+            mock_work = MagicMock()
+            with patch("torch.distributed.all_reduce", return_value=mock_work) as mock_reduce:
+                tensor = torch.tensor([1.0, 2.0, 3.0])
+                result = all_reduce(tensor, async_op=True)
+
+                mock_reduce.assert_called_once()
+                assert result is mock_work
+
+    def test_all_gather_not_distributed(self):
+        """Test all_gather returns list with tensor when not distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=False):
+            tensor = torch.tensor([1.0, 2.0])
+            result = all_gather(tensor)
+
+            assert len(result) == 1
+            assert torch.equal(result[0], tensor)
+
+    def test_all_gather_distributed(self):
+        """Test all_gather calls dist.all_gather when distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=True):
+            with patch("thinkrl.utils.distributed_util.get_world_size", return_value=2):
+                with patch("torch.distributed.all_gather") as mock_gather:
+                    tensor = torch.tensor([1.0, 2.0])
+                    result = all_gather(tensor)
+
+                    mock_gather.assert_called_once()
+                    assert len(result) == 2
+
+    def test_broadcast_not_distributed(self):
+        """Test broadcast returns tensor unchanged when not distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=False):
+            tensor = torch.tensor([1.0, 2.0])
+            result = broadcast(tensor, src=0)
+            assert torch.equal(result, tensor)
+
+    def test_broadcast_distributed(self):
+        """Test broadcast calls dist.broadcast when distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=True):
+            with patch("torch.distributed.broadcast") as mock_broadcast:
+                tensor = torch.tensor([1.0, 2.0])
+                result = broadcast(tensor, src=0)
+
+                mock_broadcast.assert_called_once_with(tensor, src=0)
+                assert result is tensor
+
+    def test_reduce_mean_not_distributed(self):
+        """Test reduce_mean returns tensor unchanged when not distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=False):
+            tensor = torch.tensor([1.0, 2.0, 3.0])
+            result = reduce_mean(tensor)
+            assert torch.equal(result, tensor)
+
+    def test_reduce_mean_distributed(self):
+        """Test reduce_mean computes mean across processes."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=True):
+            with patch("thinkrl.utils.distributed_util.get_world_size", return_value=2):
+                with patch("torch.distributed.all_reduce") as mock_reduce:
+                    tensor = torch.tensor([2.0, 4.0])
+                    result = reduce_mean(tensor)
+
+                    mock_reduce.assert_called_once()
+                    # Result should be tensor / 2
+                    assert torch.allclose(result, torch.tensor([1.0, 2.0]))
+
+
+class TestObjectCommunication:
+    """Tests for object-based communication."""
+
+    def test_gather_object_not_distributed(self):
+        """Test gather_object returns list with object when not distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=False):
+            obj = {"key": "value"}
+            result = gather_object(obj, dst=0)
+
+            assert result == [obj]
+
+    def test_gather_object_dst_rank(self):
+        """Test gather_object on destination rank."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=True):
+            with patch("thinkrl.utils.distributed_util.get_world_size", return_value=2):
+                with patch("thinkrl.utils.distributed_util.get_rank", return_value=0):
+                    with patch("torch.distributed.gather_object") as mock_gather:
+                        obj = {"key": "value"}
+                        result = gather_object(obj, dst=0)
+
+                        mock_gather.assert_called_once()
+                        assert result is not None
+
+    def test_gather_object_non_dst_rank(self):
+        """Test gather_object on non-destination rank."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=True):
+            with patch("thinkrl.utils.distributed_util.get_world_size", return_value=2):
+                with patch("thinkrl.utils.distributed_util.get_rank", return_value=1):
+                    with patch("torch.distributed.gather_object") as mock_gather:
+                        obj = {"key": "value"}
+                        result = gather_object(obj, dst=0)
+
+                        mock_gather.assert_called_once()
+                        assert result is None
+
+    def test_broadcast_object_not_distributed(self):
+        """Test broadcast_object returns object when not distributed."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=False):
+            obj = {"key": "value"}
+            result = broadcast_object(obj, src=0)
+            assert result == obj
+
+    def test_broadcast_object_distributed(self):
+        """Test broadcast_object calls dist.broadcast_object_list."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=True):
+            with patch("thinkrl.utils.distributed_util.get_rank", return_value=0):
+                with patch("torch.distributed.broadcast_object_list") as mock_broadcast:
+                    obj = {"key": "value"}
+                    result = broadcast_object(obj, src=0)
+
+                    mock_broadcast.assert_called_once()
+
+
+class TestCleanup:
+    """Tests for cleanup functions."""
+
+    def test_cleanup_distributed_not_initialized(self):
+        """Test cleanup when not distributed is no-op."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=False):
+            # Should not raise
+            cleanup_distributed()
+
+    def test_cleanup_distributed_initialized(self):
+        """Test cleanup destroys process group."""
+        with patch("thinkrl.utils.distributed_util.is_distributed", return_value=True):
+            with patch("torch.distributed.destroy_process_group") as mock_destroy:
+                cleanup_distributed()
+                mock_destroy.assert_called_once()
+
+
+class TestStatelessProcessGroup:
+    """Tests for stateless_init_process_group."""
+
+    def test_stateless_without_vllm(self):
+        """Test stateless init returns None without vLLM."""
+        with patch("thinkrl.utils.distributed_util._VLLM_AVAILABLE", False):
+            result = stateless_init_process_group(
+                master_address="localhost",
+                master_port=29500,
+                rank=0,
+                world_size=2,
+                device="cuda:0",
+            )
+            assert result is None
+
+    @pytest.mark.skipif(True, reason="Requires vLLM installation")
+    def test_stateless_with_vllm(self):
+        """Test stateless init with vLLM (requires vLLM)."""
+        # This test would require vLLM to be installed
+        pass

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -249,3 +249,112 @@ class TestLogging:
         # No log file should be created
         log_files = list(temp_dir.glob("thinkrl.rank5_*.log"))
         assert len(log_files) == 0
+
+    def test_colored_formatter_no_colors(self):
+        """Test colored formatter with colors disabled."""
+        formatter = ColoredFormatter(fmt="%(levelname)s - %(message)s", use_colors=False)
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.WARNING,
+            pathname="test.py",
+            lineno=1,
+            msg="Warning message",
+            args=(),
+            exc_info=None,
+        )
+
+        formatted = formatter.format(record)
+
+        # Should not contain color codes
+        assert "\033[" not in formatted
+        assert "Warning message" in formatted
+
+    def test_colored_formatter_different_levels(self):
+        """Test colored formatter with different log levels."""
+        formatter = ColoredFormatter(fmt="%(levelname)s - %(message)s", use_colors=True)
+
+        levels = [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL]
+
+        for level in levels:
+            record = logging.LogRecord(
+                name="test",
+                level=level,
+                pathname="test.py",
+                lineno=1,
+                msg="Test message",
+                args=(),
+                exc_info=None,
+            )
+            formatted = formatter.format(record)
+            assert "Test message" in formatted
+
+    def test_setup_logger_with_rotation(self, temp_dir):
+        """Test logger setup with log rotation."""
+        logger = setup_logger(
+            "thinkrl.rotation",
+            log_dir=temp_dir,
+            max_bytes=1024,
+            backup_count=3,
+        )
+
+        assert logger is not None
+
+        # Log some messages
+        for i in range(10):
+            logger.info(f"Test message {i}")
+
+        # Close handlers for cleanup
+        for handler in logger.handlers[:]:
+            handler.close()
+            logger.removeHandler(handler)
+
+    def test_thinkrl_logger_log_dict(self, temp_dir):
+        """Test logging dictionary data."""
+        logger = setup_logger("thinkrl.dictlog", log_dir=temp_dir)
+
+        data = {"loss": 0.5, "accuracy": 0.9, "epoch": 10}
+        logger.info(f"Training stats: {data}")
+
+        log_file = list(temp_dir.glob("thinkrl.dictlog_*.log"))[0]
+        with open(log_file) as f:
+            content = f.read()
+
+        assert "Training stats:" in content
+        assert "loss" in content
+
+    def test_setup_logger_console_only(self):
+        """Test setting up logger without file logging."""
+        logger = setup_logger("thinkrl.console_only", log_dir=None)
+
+        assert logger is not None
+        # Should only have console handler
+        stream_handlers = [h for h in logger.handlers if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)]
+        assert len(stream_handlers) >= 1
+
+    def test_thinkrl_logger_epoch_logging(self, temp_dir):
+        """Test epoch progress logging."""
+        logger = setup_logger("thinkrl.epoch", log_dir=temp_dir)
+
+        # Test progress method with different scenarios
+        logger.progress(0, 100, prefix="Epoch 1")
+        logger.progress(50, 100, prefix="Epoch 1")
+        logger.progress(100, 100, prefix="Epoch 1")
+
+        log_file = list(temp_dir.glob("thinkrl.epoch_*.log"))[0]
+        with open(log_file) as f:
+            content = f.read()
+
+        assert "Epoch 1" in content
+        assert "100%" in content
+
+    def test_get_logger_returns_existing(self):
+        """Test that get_logger returns existing configured logger."""
+        # First set up a logger
+        original = setup_logger("thinkrl.test_existing")
+
+        # Get the same logger
+        retrieved = get_logger("thinkrl.test_existing")
+
+        # Should be the same logger instance
+        assert retrieved.name == original.name

--- a/tests/test_utils/test_processor.py
+++ b/tests/test_utils/test_processor.py
@@ -1,0 +1,345 @@
+"""
+Test Suite for ThinkRL Processor Utilities
+==========================================
+
+Tests for:
+- thinkrl.utils.processor
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from thinkrl.utils.processor import (
+    PROCESSORS,
+    best_of_n_processor,
+    conditional_sft_processor,
+    create_pairwise_data,
+    filter_by_reward_threshold,
+    get_processor,
+    iterative_dpo_processor,
+    register_processor,
+    rejection_sampling_processor,
+    reward_normalization,
+)
+
+
+class TestRewardNormalization:
+    """Tests for reward_normalization function."""
+
+    def test_basic_normalization(self):
+        """Test basic z-score normalization."""
+        objs = [
+            {"input": "a", "reward": 1.0},
+            {"input": "b", "reward": 2.0},
+            {"input": "c", "reward": 3.0},
+            {"input": "d", "reward": 4.0},
+            {"input": "e", "reward": 5.0},
+        ]
+
+        result = reward_normalization(objs, reward_key="reward")
+
+        # Mean should be approximately 0
+        rewards = [obj["reward"] for obj in result]
+        mean = sum(rewards) / len(rewards)
+        assert abs(mean) < 1e-6
+
+        # Std should be approximately 1
+        variance = sum((r - mean) ** 2 for r in rewards) / len(rewards)
+        std = variance ** 0.5
+        assert abs(std - 1.0) < 0.1
+
+    def test_empty_rewards(self):
+        """Test with empty rewards list."""
+        objs = [{"input": "a"}, {"input": "b"}]
+        result = reward_normalization(objs, reward_key="reward")
+        assert result == objs
+
+    def test_custom_reward_key(self):
+        """Test with custom reward key."""
+        objs = [
+            {"input": "a", "score": 1.0},
+            {"input": "b", "score": 3.0},
+        ]
+
+        result = reward_normalization(objs, reward_key="score")
+        assert "score" in result[0]
+
+
+class TestConditionalSFTProcessor:
+    """Tests for conditional_sft_processor function."""
+
+    @pytest.fixture
+    def sample_data(self):
+        return [
+            {"input": "Question 1", "output": "Answer 1", "reward": 0.8},
+            {"input": "Question 2", "output": "Answer 2", "reward": 0.5},
+        ]
+
+    def test_basic_processing(self, sample_data):
+        """Test basic conditional SFT processing."""
+        args = MagicMock()
+        result = conditional_sft_processor(
+            args,
+            sample_data,
+            input_key="input",
+            output_key="output",
+            reward_key="reward",
+        )
+
+        assert len(result) == 2
+        assert "<rm_score>:" in result[0]["input"]
+        assert "0.8" in result[0]["input"]
+
+    def test_custom_template(self, sample_data):
+        """Test with custom template."""
+        args = MagicMock()
+        result = conditional_sft_processor(
+            args,
+            sample_data,
+            input_template="Input: {input} Score: {reward}",
+        )
+
+        assert "Input:" in result[0]["input"]
+        assert "Score:" in result[0]["input"]
+
+    def test_invalid_template(self, sample_data):
+        """Test with invalid template raises error."""
+        args = MagicMock()
+        with pytest.raises(ValueError, match="must contain"):
+            conditional_sft_processor(
+                args,
+                sample_data,
+                input_template="Invalid template",
+            )
+
+    def test_with_normalization(self, sample_data):
+        """Test with reward normalization."""
+        args = MagicMock()
+        result = conditional_sft_processor(
+            args,
+            sample_data,
+            normalize_rewards=True,
+        )
+
+        assert len(result) == 2
+
+
+class TestRejectionSamplingProcessor:
+    """Tests for rejection_sampling_processor function."""
+
+    @pytest.fixture
+    def sample_data(self):
+        return [
+            {"input": "Q1", "output": "A1", "reward": 0.5},
+            {"input": "Q1", "output": "A2", "reward": 0.9},  # Best for Q1
+            {"input": "Q2", "output": "A3", "reward": 0.7},
+            {"input": "Q2", "output": "A4", "reward": 0.3},
+        ]
+
+    def test_basic_rejection_sampling(self, sample_data):
+        """Test basic rejection sampling."""
+        args = MagicMock()
+        result = rejection_sampling_processor(args, sample_data)
+
+        assert len(result) == 2
+
+        # Check best outputs are kept
+        q1_result = next(r for r in result if r["input"] == "Q1")
+        assert q1_result["output"] == "A2"
+        assert q1_result["reward"] == 0.9
+
+        q2_result = next(r for r in result if r["input"] == "Q2")
+        assert q2_result["output"] == "A3"
+        assert q2_result["reward"] == 0.7
+
+    def test_single_output_per_input(self):
+        """Test with single output per input."""
+        data = [
+            {"input": "Q1", "output": "A1", "reward": 0.5},
+            {"input": "Q2", "output": "A2", "reward": 0.7},
+        ]
+        args = MagicMock()
+        result = rejection_sampling_processor(args, data)
+
+        assert len(result) == 2
+
+
+class TestIterativeDPOProcessor:
+    """Tests for iterative_dpo_processor function."""
+
+    @pytest.fixture
+    def sample_data(self):
+        return [
+            {"input": "Q1", "output": "Good", "reward": 0.9},
+            {"input": "Q1", "output": "Bad", "reward": 0.1},
+            {"input": "Q2", "output": "Medium", "reward": 0.5},
+            {"input": "Q2", "output": "Worst", "reward": 0.2},
+        ]
+
+    def test_basic_dpo_processing(self, sample_data):
+        """Test basic DPO pair creation."""
+        args = MagicMock()
+        result = iterative_dpo_processor(args, sample_data)
+
+        assert len(result) == 2
+
+        q1_pair = next(r for r in result if r["input"] == "Q1")
+        assert q1_pair["chosen"] == "Good"
+        assert q1_pair["rejected"] == "Bad"
+        assert q1_pair["chosen_reward"] == 0.9
+        assert q1_pair["rejected_reward"] == 0.1
+
+    def test_single_output_skipped(self):
+        """Test that inputs with single output are skipped."""
+        data = [
+            {"input": "Q1", "output": "Only", "reward": 0.5},
+            {"input": "Q2", "output": "Good", "reward": 0.9},
+            {"input": "Q2", "output": "Bad", "reward": 0.1},
+        ]
+        args = MagicMock()
+        result = iterative_dpo_processor(args, data)
+
+        assert len(result) == 1
+        assert result[0]["input"] == "Q2"
+
+
+class TestBestOfNProcessor:
+    """Tests for best_of_n_processor function."""
+
+    @pytest.fixture
+    def sample_data(self):
+        return [
+            {"input": "Q1", "output": "A1", "reward": 0.5},
+            {"input": "Q1", "output": "A2", "reward": 0.9},
+            {"input": "Q1", "output": "A3", "reward": 0.7},
+            {"input": "Q1", "output": "A4", "reward": 0.8},
+            {"input": "Q2", "output": "B1", "reward": 0.6},
+            {"input": "Q2", "output": "B2", "reward": 0.4},
+        ]
+
+    def test_best_of_4(self, sample_data):
+        """Test best-of-4 selection."""
+        args = MagicMock()
+        result = best_of_n_processor(args, sample_data, n=4)
+
+        # Only Q1 has >= 4 samples
+        assert len(result) == 1
+        assert result[0]["input"] == "Q1"
+        assert result[0]["output"] == "A2"  # Best
+        assert result[0]["reward"] == 0.9
+
+    def test_best_of_2(self, sample_data):
+        """Test best-of-2 selection."""
+        args = MagicMock()
+        result = best_of_n_processor(args, sample_data, n=2)
+
+        # Both Q1 and Q2 have >= 2 samples
+        assert len(result) == 2
+
+
+class TestFilterByRewardThreshold:
+    """Tests for filter_by_reward_threshold function."""
+
+    @pytest.fixture
+    def sample_data(self):
+        return [
+            {"input": "a", "reward": 0.9},
+            {"input": "b", "reward": 0.7},
+            {"input": "c", "reward": 0.5},
+            {"input": "d", "reward": 0.3},
+        ]
+
+    def test_filter_above_threshold(self, sample_data):
+        """Test filtering above threshold."""
+        result = filter_by_reward_threshold(sample_data, threshold=0.6, keep_above=True)
+
+        assert len(result) == 2
+        assert all(r["reward"] >= 0.6 for r in result)
+
+    def test_filter_below_threshold(self, sample_data):
+        """Test filtering below threshold."""
+        result = filter_by_reward_threshold(sample_data, threshold=0.6, keep_above=False)
+
+        assert len(result) == 2
+        assert all(r["reward"] < 0.6 for r in result)
+
+
+class TestCreatePairwiseData:
+    """Tests for create_pairwise_data function."""
+
+    @pytest.fixture
+    def sample_data(self):
+        return [
+            {"input": "Q1", "output": "A", "reward": 0.9},
+            {"input": "Q1", "output": "B", "reward": 0.5},
+            {"input": "Q1", "output": "C", "reward": 0.3},
+        ]
+
+    def test_create_pairs_no_margin(self, sample_data):
+        """Test creating pairs without margin."""
+        result = create_pairwise_data(sample_data, margin=0.0)
+
+        # For 3 outputs, we get 6 ordered pairs (n * (n-1))
+        # But only pairs where chosen > rejected
+        # A > B, A > C, B > C = 3 pairs
+        assert len(result) == 3
+
+        # Check all pairs have chosen_reward > rejected_reward
+        for pair in result:
+            assert pair["chosen_reward"] > pair["rejected_reward"]
+
+    def test_create_pairs_with_margin(self, sample_data):
+        """Test creating pairs with margin."""
+        result = create_pairwise_data(sample_data, margin=0.3)
+
+        # Only pairs with reward diff >= 0.3
+        # A-B: 0.4, A-C: 0.6, B-C: 0.2 -> 2 pairs
+        assert len(result) == 2
+
+
+class TestProcessorRegistry:
+    """Tests for processor registry functions."""
+
+    def test_get_processor_valid(self):
+        """Test getting valid processor."""
+        processor = get_processor("rs")
+        assert processor is rejection_sampling_processor
+
+        processor = get_processor("rejection_sampling")
+        assert processor is rejection_sampling_processor
+
+    def test_get_processor_invalid(self):
+        """Test getting invalid processor raises error."""
+        with pytest.raises(ValueError, match="Unknown processor"):
+            get_processor("invalid_processor")
+
+    def test_register_processor(self):
+        """Test registering custom processor."""
+
+        def my_processor(args, objs):
+            return objs
+
+        register_processor("my_custom", my_processor)
+
+        assert "my_custom" in PROCESSORS
+        assert get_processor("my_custom") is my_processor
+
+        # Cleanup
+        del PROCESSORS["my_custom"]
+
+    def test_all_processors_registered(self):
+        """Test that all standard processors are registered."""
+        expected = [
+            "rs",
+            "rejection_sampling",
+            "csft",
+            "conditional_sft",
+            "iter_dpo",
+            "iterative_dpo",
+            "best_of_n",
+            "bon",
+        ]
+
+        for name in expected:
+            assert name in PROCESSORS

--- a/tests/test_utils/test_processor.py
+++ b/tests/test_utils/test_processor.py
@@ -6,7 +6,7 @@ Tests for:
 - thinkrl.utils.processor
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_utils/test_remote_rm_utils.py
+++ b/tests/test_utils/test_remote_rm_utils.py
@@ -1,0 +1,308 @@
+"""
+Test Suite for ThinkRL Remote Reward Model Utilities
+=====================================================
+
+Tests for:
+- thinkrl.utils.remote_rm_utils
+"""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from thinkrl.utils.remote_rm_utils import (
+    RemoteRewardModel,
+    create_reward_server_handler,
+    request_api_wrapper,
+    _REQUESTS_AVAILABLE,
+    _RAY_AVAILABLE,
+)
+
+
+class TestRequestAPIWrapper:
+    """Tests for request_api_wrapper function."""
+
+    def test_without_requests_library(self):
+        """Test that missing requests library raises error."""
+        with patch("thinkrl.utils.remote_rm_utils._REQUESTS_AVAILABLE", False):
+            with pytest.raises(RuntimeError, match="requests library is required"):
+                request_api_wrapper("http://localhost:8000", {"data": "test"})
+
+    @pytest.mark.skipif(not _REQUESTS_AVAILABLE, reason="requests not installed")
+    def test_successful_request(self):
+        """Test successful API request."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"rewards": [0.5, 0.7]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response):
+            result = request_api_wrapper(
+                "http://localhost:8000/reward",
+                {"queries": ["text1", "text2"]},
+            )
+
+            assert result == {"rewards": [0.5, 0.7]}
+
+    @pytest.mark.skipif(not _REQUESTS_AVAILABLE, reason="requests not installed")
+    def test_request_retry_on_failure(self):
+        """Test request retries on failure."""
+        import requests
+
+        call_count = 0
+
+        def mock_post(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise requests.exceptions.RequestException("Connection failed")
+            response = MagicMock()
+            response.json.return_value = {"rewards": [0.5]}
+            response.raise_for_status = MagicMock()
+            return response
+
+        with patch("requests.post", side_effect=mock_post):
+            with patch("time.sleep"):  # Skip sleep for faster tests
+                result = request_api_wrapper(
+                    "http://localhost:8000/reward",
+                    {"queries": ["text"]},
+                    try_max_times=5,
+                    retry_delay=0.1,
+                )
+
+        assert result == {"rewards": [0.5]}
+        assert call_count == 3
+
+    @pytest.mark.skipif(not _REQUESTS_AVAILABLE, reason="requests not installed")
+    def test_request_all_retries_fail(self):
+        """Test that all retries failing returns None."""
+        import requests
+
+        with patch("requests.post", side_effect=requests.exceptions.RequestException("Failed")):
+            with patch("time.sleep"):
+                result = request_api_wrapper(
+                    "http://localhost:8000/reward",
+                    {"queries": ["text"]},
+                    try_max_times=3,
+                )
+
+        assert result is None
+
+
+class TestRemoteRewardModel:
+    """Tests for RemoteRewardModel class."""
+
+    def test_init_with_single_url(self):
+        """Test initialization with single URL."""
+        rm = RemoteRewardModel(remote_urls="http://localhost:8000")
+
+        assert rm.remote_urls == ["http://localhost:8000"]
+        assert rm.reward_fn is None
+
+    def test_init_with_multiple_urls(self):
+        """Test initialization with multiple URLs."""
+        urls = ["http://localhost:8000", "http://localhost:8001"]
+        rm = RemoteRewardModel(remote_urls=urls)
+
+        assert rm.remote_urls == urls
+
+    def test_init_no_source_warning(self, caplog):
+        """Test warning when no source is provided."""
+        import logging
+        with caplog.at_level(logging.WARNING):
+            rm = RemoteRewardModel()
+
+        assert "No remote URLs or reward function specified" in caplog.text
+
+    def test_get_rewards_empty_queries(self):
+        """Test get_rewards with empty queries list."""
+        rm = RemoteRewardModel(remote_urls=["http://localhost:8000"])
+        result = rm.get_rewards([])
+        assert result == []
+
+    def test_get_rewards_no_source(self, caplog):
+        """Test get_rewards with no source returns zeros."""
+        import logging
+        rm = RemoteRewardModel()
+
+        with caplog.at_level(logging.WARNING):
+            result = rm.get_rewards(["query1", "query2"])
+
+        assert result == [0.0, 0.0]
+        assert "No reward source available" in caplog.text
+
+    @pytest.fixture
+    def temp_reward_fn_file(self):
+        """Create a temporary file with reward function."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("""
+def compute_reward(queries, prompts=None, labels=None):
+    return [len(q) / 100.0 for q in queries]
+""")
+            f.flush()
+            yield f.name
+        os.unlink(f.name)
+
+    def test_init_with_reward_fn(self, temp_reward_fn_file):
+        """Test initialization with custom reward function."""
+        rm = RemoteRewardModel(
+            reward_fn_path=temp_reward_fn_file,
+            reward_fn_name="compute_reward",
+        )
+
+        assert rm.reward_fn is not None
+
+    def test_get_rewards_with_custom_fn(self, temp_reward_fn_file):
+        """Test get_rewards with custom function."""
+        rm = RemoteRewardModel(
+            reward_fn_path=temp_reward_fn_file,
+            reward_fn_name="compute_reward",
+            use_ray=False,
+        )
+
+        queries = ["short", "medium length text"]
+        result = rm.get_rewards(queries)
+
+        assert len(result) == 2
+        assert result[0] == 5 / 100.0  # "short" = 5 chars
+        assert result[1] == 18 / 100.0  # "medium length text" = 18 chars
+
+    def test_load_reward_fn_file_not_found(self):
+        """Test loading reward function from non-existent file."""
+        with pytest.raises(FileNotFoundError):
+            RemoteRewardModel(
+                reward_fn_path="/nonexistent/path.py",
+                reward_fn_name="compute_reward",
+            )
+
+    def test_load_reward_fn_function_not_found(self, temp_reward_fn_file):
+        """Test loading non-existent function from file."""
+        with pytest.raises(AttributeError, match="not found"):
+            RemoteRewardModel(
+                reward_fn_path=temp_reward_fn_file,
+                reward_fn_name="nonexistent_function",
+            )
+
+    @pytest.mark.skipif(not _REQUESTS_AVAILABLE, reason="requests not installed")
+    def test_get_rewards_from_servers_no_ray(self):
+        """Test get_rewards from remote servers without Ray."""
+        rm = RemoteRewardModel(
+            remote_urls=["http://localhost:8000"],
+            use_ray=False,
+        )
+
+        mock_response = {"rewards": [0.5, 0.7]}
+
+        with patch("thinkrl.utils.remote_rm_utils.request_api_wrapper", return_value=mock_response):
+            result = rm.get_rewards(["query1", "query2"])
+
+        assert result == [0.5, 0.7]
+
+    @pytest.mark.skipif(not _REQUESTS_AVAILABLE, reason="requests not installed")
+    def test_get_rewards_from_servers_request_failed(self):
+        """Test get_rewards handles failed requests gracefully."""
+        rm = RemoteRewardModel(
+            remote_urls=["http://localhost:8000"],
+            use_ray=False,
+        )
+
+        with patch("thinkrl.utils.remote_rm_utils.request_api_wrapper", return_value=None):
+            result = rm.get_rewards(["query1", "query2"])
+
+        assert result == [0.0, 0.0]
+
+
+class TestCreateRewardServerHandler:
+    """Tests for create_reward_server_handler function."""
+
+    def test_create_handler(self):
+        """Test creating a handler from reward function."""
+
+        def my_reward_fn(queries, prompts=None, labels=None):
+            return [len(q) / 10.0 for q in queries]
+
+        handler = create_reward_server_handler(my_reward_fn)
+
+        assert callable(handler)
+
+    def test_handler_success(self):
+        """Test handler processes request successfully."""
+
+        def my_reward_fn(queries, prompts=None, labels=None):
+            return [0.5, 0.7]
+
+        handler = create_reward_server_handler(my_reward_fn)
+
+        data = {"queries": ["query1", "query2"]}
+        result = handler(data)
+
+        assert result["status"] == "success"
+        assert result["rewards"] == [0.5, 0.7]
+
+    def test_handler_with_prompts_and_labels(self):
+        """Test handler passes prompts and labels."""
+
+        def my_reward_fn(queries, prompts=None, labels=None):
+            assert prompts is not None
+            assert labels is not None
+            return [0.5]
+
+        handler = create_reward_server_handler(my_reward_fn)
+
+        data = {
+            "queries": ["query1"],
+            "prompts": ["prompt1"],
+            "labels": ["label1"],
+        }
+        result = handler(data)
+
+        assert result["status"] == "success"
+
+    def test_handler_error(self):
+        """Test handler handles errors gracefully."""
+
+        def failing_reward_fn(queries, prompts=None, labels=None):
+            raise ValueError("Reward computation failed")
+
+        handler = create_reward_server_handler(failing_reward_fn)
+
+        data = {"queries": ["query1"]}
+        result = handler(data)
+
+        assert result["status"] == "error"
+        assert "error" in result
+        assert result["rewards"] == [0.0]
+
+
+class TestRemoteRewardModelMicroBatching:
+    """Tests for micro-batching in RemoteRewardModel."""
+
+    @pytest.fixture
+    def temp_reward_fn_file(self):
+        """Create a temporary file with reward function."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("""
+def compute_reward(queries, prompts=None, labels=None):
+    return [1.0 for q in queries]
+""")
+            f.flush()
+            yield f.name
+        os.unlink(f.name)
+
+    def test_micro_batching(self, temp_reward_fn_file):
+        """Test that large inputs are processed in micro-batches."""
+        rm = RemoteRewardModel(
+            reward_fn_path=temp_reward_fn_file,
+            reward_fn_name="compute_reward",
+            micro_batch_size=10,
+            use_ray=False,
+        )
+
+        # Create 25 queries (should be processed in 3 batches: 10, 10, 5)
+        queries = [f"query_{i}" for i in range(25)]
+
+        result = rm.get_rewards(queries)
+
+        assert len(result) == 25
+        assert all(r == 1.0 for r in result)

--- a/tests/test_utils/test_remote_rm_utils.py
+++ b/tests/test_utils/test_remote_rm_utils.py
@@ -17,7 +17,6 @@ from thinkrl.utils.remote_rm_utils import (
     create_reward_server_handler,
     request_api_wrapper,
     _REQUESTS_AVAILABLE,
-    _RAY_AVAILABLE,
 )
 
 
@@ -111,7 +110,7 @@ class TestRemoteRewardModel:
         """Test warning when no source is provided."""
         import logging
         with caplog.at_level(logging.WARNING):
-            rm = RemoteRewardModel()
+            RemoteRewardModel()
 
         assert "No remote URLs or reward function specified" in caplog.text
 

--- a/tests/test_utils/test_seqlen_balancing.py
+++ b/tests/test_utils/test_seqlen_balancing.py
@@ -251,7 +251,7 @@ class TestLogSeqlenUnbalance:
         partitions = [[0], [1]]
 
         with caplog.at_level(logging.INFO):
-            metrics = log_seqlen_unbalance(
+            log_seqlen_unbalance(
                 seqlen_list,
                 partitions,
                 prefix="Batch 0: ",
@@ -303,7 +303,7 @@ class TestGetMinimumNumMicroBatchSize:
         total_lengths = [3000, 500]
 
         with caplog.at_level(logging.WARNING):
-            min_batches = get_minimum_num_micro_batch_size(
+            get_minimum_num_micro_batch_size(
                 total_lengths,
                 max_tokens_per_gpu=2048,
             )

--- a/tests/test_utils/test_seqlen_balancing.py
+++ b/tests/test_utils/test_seqlen_balancing.py
@@ -1,0 +1,389 @@
+"""
+Test Suite for ThinkRL Sequence Length Balancing Utilities
+===========================================================
+
+Tests for:
+- thinkrl.utils.seqlen_balancing
+"""
+
+import pytest
+
+from thinkrl.utils.seqlen_balancing import (
+    ceildiv,
+    get_minimum_num_micro_batch_size,
+    get_reverse_idx,
+    get_seqlen_balanced_partitions,
+    greedy_partition,
+    karmarkar_karp,
+    log_seqlen_unbalance,
+    reorder_by_seqlen,
+)
+
+
+class TestCeilDiv:
+    """Tests for ceildiv function."""
+
+    def test_even_division(self):
+        """Test even division."""
+        assert ceildiv(10, 5) == 2
+        assert ceildiv(100, 10) == 10
+
+    def test_uneven_division(self):
+        """Test uneven division rounds up."""
+        assert ceildiv(10, 3) == 4
+        assert ceildiv(7, 2) == 4
+        assert ceildiv(1, 3) == 1
+
+    def test_one_divisor(self):
+        """Test division by 1."""
+        assert ceildiv(10, 1) == 10
+        assert ceildiv(1, 1) == 1
+
+    def test_larger_divisor(self):
+        """Test when divisor is larger than numerator."""
+        assert ceildiv(3, 10) == 1
+
+
+class TestGetReverseIdx:
+    """Tests for get_reverse_idx function."""
+
+    def test_simple_reverse(self):
+        """Test simple reverse mapping."""
+        idx_map = [2, 0, 1]
+        reverse = get_reverse_idx(idx_map)
+
+        # If idx_map[i] = j, then reverse[j] = i
+        assert reverse == [1, 2, 0]
+
+    def test_identity_mapping(self):
+        """Test identity mapping."""
+        idx_map = [0, 1, 2, 3]
+        reverse = get_reverse_idx(idx_map)
+        assert reverse == [0, 1, 2, 3]
+
+    def test_fully_reversed(self):
+        """Test fully reversed mapping."""
+        idx_map = [3, 2, 1, 0]
+        reverse = get_reverse_idx(idx_map)
+        assert reverse == [3, 2, 1, 0]
+
+    def test_roundtrip(self):
+        """Test that applying reverse twice gives original indices."""
+        idx_map = [4, 2, 0, 3, 1]
+        reverse = get_reverse_idx(idx_map)
+        double_reverse = get_reverse_idx(reverse)
+        assert double_reverse == idx_map
+
+
+class TestKarmarkarKarp:
+    """Tests for karmarkar_karp function."""
+
+    def test_basic_partition(self):
+        """Test basic partitioning."""
+        seqlen_list = [100, 50, 75, 25, 80, 45]
+        partitions = karmarkar_karp(seqlen_list, k_partitions=2)
+
+        assert len(partitions) == 2
+
+        # All indices should be covered exactly once
+        all_indices = []
+        for p in partitions:
+            all_indices.extend(p)
+        assert sorted(all_indices) == list(range(6))
+
+    def test_equal_size_partitions(self):
+        """Test equal size constraint."""
+        seqlen_list = [100, 50, 75, 25, 80, 45]
+        partitions = karmarkar_karp(seqlen_list, k_partitions=2, equal_size=True)
+
+        # Each partition should have 3 elements
+        assert len(partitions[0]) == 3
+        assert len(partitions[1]) == 3
+
+    def test_more_partitions_than_items(self):
+        """Test when more partitions than items."""
+        seqlen_list = [100, 50]
+        partitions = karmarkar_karp(seqlen_list, k_partitions=4)
+
+        assert len(partitions) == 4
+
+        # Two partitions should have items, two should be empty
+        non_empty = [p for p in partitions if len(p) > 0]
+        empty = [p for p in partitions if len(p) == 0]
+
+        assert len(non_empty) == 2
+        assert len(empty) == 2
+
+    def test_single_partition(self):
+        """Test single partition."""
+        seqlen_list = [100, 50, 75]
+        partitions = karmarkar_karp(seqlen_list, k_partitions=1)
+
+        assert len(partitions) == 1
+        assert len(partitions[0]) == 3
+
+    def test_balance_quality(self):
+        """Test that partitions are reasonably balanced."""
+        seqlen_list = [100, 90, 80, 70, 60, 50]
+        partitions = karmarkar_karp(seqlen_list, k_partitions=3, equal_size=True)
+
+        # Compute sums
+        sums = [sum(seqlen_list[i] for i in p) for p in partitions]
+
+        # The algorithm should produce fairly balanced sums
+        # Total is 450, ideal is 150 per partition
+        for s in sums:
+            assert 100 < s < 200  # Allow some variance
+
+
+class TestGreedyPartition:
+    """Tests for greedy_partition function."""
+
+    def test_basic_partition(self):
+        """Test basic partitioning."""
+        seqlen_list = [100, 50, 75, 25, 80, 45]
+        partitions = greedy_partition(seqlen_list, k_partitions=2)
+
+        assert len(partitions) == 2
+
+        # All indices should be covered
+        all_indices = []
+        for p in partitions:
+            all_indices.extend(p)
+        assert sorted(all_indices) == list(range(6))
+
+    def test_equal_size_constraint(self):
+        """Test equal size partitions."""
+        seqlen_list = [100, 50, 75, 25, 80, 45, 60, 55]
+        partitions = greedy_partition(seqlen_list, k_partitions=4, equal_size=True)
+
+        # Each partition should have 2 elements
+        for p in partitions:
+            assert len(p) == 2
+
+    def test_unequal_size_partitions(self):
+        """Test unequal size partitions."""
+        seqlen_list = [100, 50, 75, 25, 80, 45]
+        partitions = greedy_partition(seqlen_list, k_partitions=3, equal_size=False)
+
+        assert len(partitions) == 3
+        # Total elements should still be 6
+        assert sum(len(p) for p in partitions) == 6
+
+    def test_more_partitions_than_items(self):
+        """Test when more partitions than items."""
+        seqlen_list = [100, 50]
+        partitions = greedy_partition(seqlen_list, k_partitions=4)
+
+        assert len(partitions) == 4
+
+
+class TestGetSeqlenBalancedPartitions:
+    """Tests for get_seqlen_balanced_partitions function."""
+
+    def test_greedy_algorithm(self):
+        """Test with greedy algorithm."""
+        seqlen_list = [100, 50, 75, 25]
+        partitions = get_seqlen_balanced_partitions(
+            seqlen_list,
+            k_partitions=2,
+            algorithm="greedy",
+        )
+
+        assert len(partitions) == 2
+
+    def test_karmarkar_karp_algorithm(self):
+        """Test with Karmarkar-Karp algorithm."""
+        seqlen_list = [100, 50, 75, 25]
+        partitions = get_seqlen_balanced_partitions(
+            seqlen_list,
+            k_partitions=2,
+            algorithm="karmarkar_karp",
+        )
+
+        assert len(partitions) == 2
+
+    def test_invalid_algorithm(self):
+        """Test with invalid algorithm raises error."""
+        with pytest.raises(ValueError, match="Unknown algorithm"):
+            get_seqlen_balanced_partitions(
+                [100, 50],
+                k_partitions=2,
+                algorithm="invalid",
+            )
+
+
+class TestLogSeqlenUnbalance:
+    """Tests for log_seqlen_unbalance function."""
+
+    def test_basic_metrics(self):
+        """Test basic metrics computation."""
+        seqlen_list = [100, 50, 75, 25, 80, 45]
+        partitions = [[0, 3], [1, 2], [4, 5]]
+
+        metrics = log_seqlen_unbalance(seqlen_list, partitions)
+
+        assert "min_sum" in metrics
+        assert "max_sum" in metrics
+        assert "mean_sum" in metrics
+        assert "imbalance_ratio" in metrics
+        assert "max_min_ratio" in metrics
+        assert "partition_sums" in metrics
+        assert "partition_sizes" in metrics
+
+    def test_partition_sums(self):
+        """Test partition sum computation."""
+        seqlen_list = [100, 50, 75, 25]
+        partitions = [[0, 3], [1, 2]]  # [100+25, 50+75]
+
+        metrics = log_seqlen_unbalance(seqlen_list, partitions)
+
+        assert metrics["partition_sums"] == [125, 125]
+        assert metrics["min_sum"] == 125
+        assert metrics["max_sum"] == 125
+        assert metrics["imbalance_ratio"] == 0.0
+
+    def test_with_prefix(self, caplog):
+        """Test logging with prefix."""
+        import logging
+
+        seqlen_list = [100, 50]
+        partitions = [[0], [1]]
+
+        with caplog.at_level(logging.INFO):
+            metrics = log_seqlen_unbalance(
+                seqlen_list,
+                partitions,
+                prefix="Batch 0: ",
+            )
+
+        assert "Batch 0:" in caplog.text
+
+
+class TestGetMinimumNumMicroBatchSize:
+    """Tests for get_minimum_num_micro_batch_size function."""
+
+    def test_basic_packing(self):
+        """Test basic first-fit packing."""
+        total_lengths = [512, 256, 1024, 128, 768]
+        min_batches = get_minimum_num_micro_batch_size(
+            total_lengths,
+            max_tokens_per_gpu=2048,
+        )
+
+        # 512+256+128 < 2048, 1024+768 < 2048
+        # So should need at least 2 batches
+        assert min_batches >= 1
+        assert min_batches <= 3
+
+    def test_all_fit_in_one(self):
+        """Test when all sequences fit in one batch."""
+        total_lengths = [100, 200, 300]
+        min_batches = get_minimum_num_micro_batch_size(
+            total_lengths,
+            max_tokens_per_gpu=1000,
+        )
+
+        assert min_batches == 1
+
+    def test_each_needs_own_batch(self):
+        """Test when each sequence needs its own batch."""
+        total_lengths = [1000, 1000, 1000]
+        min_batches = get_minimum_num_micro_batch_size(
+            total_lengths,
+            max_tokens_per_gpu=1000,
+        )
+
+        assert min_batches == 3
+
+    def test_sequence_exceeds_max_warning(self, caplog):
+        """Test warning when sequence exceeds max tokens."""
+        import logging
+
+        total_lengths = [3000, 500]
+
+        with caplog.at_level(logging.WARNING):
+            min_batches = get_minimum_num_micro_batch_size(
+                total_lengths,
+                max_tokens_per_gpu=2048,
+            )
+
+        assert "exceeds max tokens" in caplog.text
+
+    def test_with_ring_attention(self):
+        """Test with ring attention parallelism."""
+        total_lengths = [1000, 1000]
+        min_batches = get_minimum_num_micro_batch_size(
+            total_lengths,
+            max_tokens_per_gpu=512,
+            ring_attn_size=2,  # Effective max = 1024
+        )
+
+        assert min_batches == 2
+
+    def test_with_tensor_parallel(self):
+        """Test with tensor parallelism."""
+        total_lengths = [1000, 1000]
+        min_batches = get_minimum_num_micro_batch_size(
+            total_lengths,
+            max_tokens_per_gpu=512,
+            ds_tensor_parallel_size=2,  # Effective max = 1024
+        )
+
+        assert min_batches == 2
+
+
+class TestReorderBySeqlen:
+    """Tests for reorder_by_seqlen function."""
+
+    def test_basic_reorder(self):
+        """Test basic reordering by length."""
+        sequences = ["a", "medium", "bb"]
+        reordered, restore_indices = reorder_by_seqlen(sequences)
+
+        # Should be sorted by length descending
+        assert reordered == ["medium", "bb", "a"]
+
+    def test_restore_original_order(self):
+        """Test that restore indices work correctly."""
+        sequences = ["short", "medium length", "a"]
+        reordered, restore_indices = reorder_by_seqlen(sequences)
+
+        # Restore original order
+        original = [reordered[i] for i in restore_indices]
+        assert original == sequences
+
+    def test_ascending_order(self):
+        """Test reordering in ascending order."""
+        sequences = ["medium", "a", "longest"]
+        reordered, restore_indices = reorder_by_seqlen(sequences, descending=False)
+
+        # Should be sorted ascending
+        lengths = [len(s) for s in reordered]
+        assert lengths == sorted(lengths)
+
+    def test_with_precomputed_lengths(self):
+        """Test with precomputed length list."""
+        sequences = [{"text": "a"}, {"text": "bb"}, {"text": "ccc"}]
+        lengths = [1, 2, 3]
+
+        reordered, restore_indices = reorder_by_seqlen(sequences, seqlen_list=lengths)
+
+        # Should be sorted by provided lengths
+        assert reordered == [{"text": "ccc"}, {"text": "bb"}, {"text": "a"}]
+
+    def test_empty_sequences(self):
+        """Test with empty sequences list."""
+        sequences = []
+        reordered, restore_indices = reorder_by_seqlen(sequences)
+
+        assert reordered == []
+        assert restore_indices == []
+
+    def test_single_sequence(self):
+        """Test with single sequence."""
+        sequences = ["only one"]
+        reordered, restore_indices = reorder_by_seqlen(sequences)
+
+        assert reordered == ["only one"]
+        assert restore_indices == [0]

--- a/tests/test_utils/test_tokenizer.py
+++ b/tests/test_utils/test_tokenizer.py
@@ -252,3 +252,85 @@ class TestTokenizers:
         assert len(loaded_tokenizer) == len(tokenizer_to_save)
         assert loaded_tokenizer.convert_tokens_to_ids("<|my_token|>") == 50257
         assert loaded_tokenizer.pad_token_id == 50256
+
+    def test_tokenize_text_without_return_tensors(self, gpt2_tokenizer):
+        """Test tokenization without return_tensors."""
+        text = "Hello world"
+        encoded = tokenize_text(text, gpt2_tokenizer, return_tensors=None)
+
+        assert "input_ids" in encoded
+        assert isinstance(encoded["input_ids"], list)
+
+    def test_decode_single_sequence(self, gpt2_tokenizer):
+        """Test decoding a single sequence with skip_special_tokens=False."""
+        token_ids = [gpt2_tokenizer.eos_token_id]
+        decoded = decode_tokens(token_ids, gpt2_tokenizer, skip_special_tokens=False)
+
+        assert gpt2_tokenizer.eos_token in decoded
+
+    def test_count_tokens_single(self, gpt2_tokenizer):
+        """Test counting tokens without special tokens."""
+        text = "Hello"
+        count = count_tokens(text, gpt2_tokenizer, add_special_tokens=False)
+
+        assert count > 0
+
+    def test_truncate_no_truncation_needed(self, gpt2_tokenizer):
+        """Test truncate when text is already short enough."""
+        text = "Short"
+        truncated = truncate_to_token_limit(text, gpt2_tokenizer, max_tokens=100)
+
+        assert truncated == text
+
+    def test_tokenizer_config_to_dict(self):
+        """Test TokenizerConfig to_dict method."""
+        from thinkrl.utils.tokenizer import TokenizerConfig
+
+        config = TokenizerConfig(
+            model_name_or_path="gpt2",
+            use_fast=True,
+            padding_side="left",
+            max_length=512,
+            custom_arg="value",
+        )
+
+        config_dict = config.to_dict()
+
+        assert config_dict["model_name_or_path"] == "gpt2"
+        assert config_dict["use_fast"] is True
+        assert config_dict["padding_side"] == "left"
+        assert config_dict["max_length"] == 512
+        assert config_dict["custom_arg"] == "value"
+
+    def test_get_tokenizer_with_unk_fallback(self):
+        """Test that tokenizer falls back to unk_token when eos is None."""
+        # This test is tricky since GPT-2 always has eos_token
+        # Just test that the function works with default tokenizer
+        tokenizer = get_tokenizer("gpt2")
+        assert tokenizer.pad_token is not None
+
+    def test_tokenize_conversation_unknown_role(self, gpt2_tokenizer):
+        """Test conversation with unknown role."""
+        messages = [
+            {"role": "unknown", "content": "Hello!"},
+        ]
+
+        encoded = tokenize_conversation(
+            messages,
+            gpt2_tokenizer,
+            system_prefix="SYS: ",
+            user_prefix="USER: ",
+            assistant_prefix="ASSIST: ",
+        )
+
+        decoded = decode_tokens(encoded["input_ids"].squeeze(0), gpt2_tokenizer)
+        # Unknown role should just include the content without prefix
+        assert "Hello!" in decoded
+
+    def test_tokenize_batch_no_batch_size(self, gpt2_tokenizer):
+        """Test tokenize_batch without specifying batch_size."""
+        texts = ["Text 1", "Text 2", "Text 3"]
+        encoded = tokenize_batch(texts, gpt2_tokenizer, padding=True)
+
+        assert "input_ids" in encoded
+        assert encoded["input_ids"].shape[0] == 3

--- a/thinkrl/data/loaders.py
+++ b/thinkrl/data/loaders.py
@@ -77,3 +77,44 @@ class RLHFDataLoader(DataLoader):
             drop_last=drop_last,
             **kwargs,
         )
+
+
+def create_rlhf_dataloader(
+    dataset,
+    tokenizer,
+    batch_size: int = 32,
+    shuffle: bool = True,
+    drop_last: bool = True,
+    padding_side: str = "right",
+    num_workers: int = 0,
+    pin_memory: bool = False,
+    **kwargs,
+) -> RLHFDataLoader:
+    """
+    Factory function to create an RLHF DataLoader with sensible defaults.
+
+    Args:
+        dataset: The dataset to load
+        tokenizer: Tokenizer for padding configuration
+        batch_size: Batch size for training
+        shuffle: Whether to shuffle the dataset
+        drop_last: Whether to drop the last incomplete batch
+        padding_side: Side to pad sequences ("left" or "right")
+        num_workers: Number of worker processes for data loading
+        pin_memory: Whether to pin memory for faster GPU transfer
+        **kwargs: Additional arguments passed to DataLoader
+
+    Returns:
+        RLHFDataLoader instance
+    """
+    return RLHFDataLoader(
+        dataset=dataset,
+        tokenizer=tokenizer,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        drop_last=drop_last,
+        padding_side=padding_side,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+        **kwargs,
+    )


### PR DESCRIPTION
- Fix ImportError for create_rlhf_dataloader by adding factory function to thinkrl/data/loaders.py
- Add test suites for low-coverage utils modules:
  - test_agent.py: Tests for AgentState, AgentInstanceBase, AgentExecutorBase
  - test_distributed_sampler.py: Tests for distributed sampling utilities
  - test_distributed_util.py: Tests for distributed communication functions
  - test_processor.py: Tests for reward processing and data transformation
  - test_remote_rm_utils.py: Tests for remote reward model utilities
  - test_seqlen_balancing.py: Tests for sequence length partitioning algorithms
- Extend existing test files with additional edge case coverage:
  - test_checkpoint.py: Optimizer loading, auto naming, latest checkpoint
  - test_data.py: zero_pad_sequences, remove_pad_token, convert_token_to_id
  - test_logging.py: Colored formatter, rotation, different log levels
  - test_tokenizer.py: Chat template, truncation, TokenizerConfig

Total: 2,864 lines of new test code targeting 80%+ coverage.