### PR TITLE
Fix TensorBoard logger import error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "function"
 
 addopts = """
     --verbose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 addopts = """
     --verbose

--- a/tests/test_logging_module/test_tensorboard.py
+++ b/tests/test_logging_module/test_tensorboard.py
@@ -105,3 +105,128 @@ class TestTensorBoardLoggerWithoutTensorBoard:
 
         with pytest.raises(ImportError):
             TensorBoardLogger()
+
+
+class TestTensorBoardLoggerMocked:
+    """Tests for TensorBoardLogger with mocked SummaryWriter."""
+
+    @patch("thinkrl.logging.tensorboard.SummaryWriter")
+    @patch("thinkrl.logging.tensorboard.TENSORBOARD_AVAILABLE", True)
+    def test_log_histogram(self, mock_writer_class):
+        """Test log_histogram method."""
+        mock_writer = MagicMock()
+        mock_writer_class.return_value = mock_writer
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = TensorBoardLogger(log_dir=tmpdir)
+            logger.log_histogram("weights", [0.1, 0.2, 0.3, 0.4], step=1)
+
+            mock_writer.add_histogram.assert_called_once_with(
+                "weights", [0.1, 0.2, 0.3, 0.4], 1, bins="tensorflow"
+            )
+            logger.finish()
+
+    @patch("thinkrl.logging.tensorboard.SummaryWriter")
+    @patch("thinkrl.logging.tensorboard.TENSORBOARD_AVAILABLE", True)
+    def test_log_image(self, mock_writer_class):
+        """Test log_image method."""
+        mock_writer = MagicMock()
+        mock_writer_class.return_value = mock_writer
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = TensorBoardLogger(log_dir=tmpdir)
+            # Simulate a simple image tensor (3, 32, 32)
+            fake_image = [[1, 2], [3, 4]]
+            logger.log_image("sample_image", fake_image, step=1)
+
+            mock_writer.add_image.assert_called_once_with(
+                "sample_image", fake_image, 1, dataformats="CHW"
+            )
+            logger.finish()
+
+    @patch("thinkrl.logging.tensorboard.SummaryWriter")
+    @patch("thinkrl.logging.tensorboard.TENSORBOARD_AVAILABLE", True)
+    def test_log_metrics(self, mock_writer_class):
+        """Test log method calls add_scalar for each metric."""
+        mock_writer = MagicMock()
+        mock_writer_class.return_value = mock_writer
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = TensorBoardLogger(log_dir=tmpdir)
+            logger.log({"loss": 0.5, "accuracy": 0.9}, step=10)
+
+            assert mock_writer.add_scalar.call_count == 2
+            logger.finish()
+
+    @patch("thinkrl.logging.tensorboard.SummaryWriter")
+    @patch("thinkrl.logging.tensorboard.TENSORBOARD_AVAILABLE", True)
+    def test_log_hyperparams_with_none_values(self, mock_writer_class):
+        """Test log_hyperparams handles None values."""
+        mock_writer = MagicMock()
+        mock_writer_class.return_value = mock_writer
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = TensorBoardLogger(log_dir=tmpdir)
+            logger.log_hyperparams({"lr": 1e-4, "scheduler": None, "model": "gpt2"})
+
+            mock_writer.add_hparams.assert_called_once()
+            call_args = mock_writer.add_hparams.call_args[0][0]
+            assert call_args["scheduler"] == "None"
+            logger.finish()
+
+    @patch("thinkrl.logging.tensorboard.SummaryWriter")
+    @patch("thinkrl.logging.tensorboard.TENSORBOARD_AVAILABLE", True)
+    def test_log_hyperparams_with_complex_values(self, mock_writer_class):
+        """Test log_hyperparams converts complex values to strings."""
+        mock_writer = MagicMock()
+        mock_writer_class.return_value = mock_writer
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = TensorBoardLogger(log_dir=tmpdir)
+            logger.log_hyperparams({"config": {"nested": "dict"}, "lr": 0.01})
+
+            mock_writer.add_hparams.assert_called_once()
+            call_args = mock_writer.add_hparams.call_args[0][0]
+            # Complex values are converted to strings
+            assert isinstance(call_args["config"], str)
+            logger.finish()
+
+    @patch("thinkrl.logging.tensorboard.SummaryWriter")
+    @patch("thinkrl.logging.tensorboard.TENSORBOARD_AVAILABLE", True)
+    def test_writer_property(self, mock_writer_class):
+        """Test writer property returns the SummaryWriter instance."""
+        mock_writer = MagicMock()
+        mock_writer_class.return_value = mock_writer
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = TensorBoardLogger(log_dir=tmpdir)
+            assert logger.writer is mock_writer
+            logger.finish()
+
+    @patch("thinkrl.logging.tensorboard.SummaryWriter")
+    @patch("thinkrl.logging.tensorboard.TENSORBOARD_AVAILABLE", True)
+    def test_log_text_with_default_step(self, mock_writer_class):
+        """Test log_text uses default step when None."""
+        mock_writer = MagicMock()
+        mock_writer_class.return_value = mock_writer
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = TensorBoardLogger(log_dir=tmpdir)
+            logger.log_text("tag", "some text")
+
+            mock_writer.add_text.assert_called_once_with("tag", "some text", global_step=0)
+            logger.finish()
+
+    @patch("thinkrl.logging.tensorboard.SummaryWriter")
+    @patch("thinkrl.logging.tensorboard.TENSORBOARD_AVAILABLE", True)
+    def test_finish_flushes_and_closes(self, mock_writer_class):
+        """Test finish method flushes and closes writer."""
+        mock_writer = MagicMock()
+        mock_writer_class.return_value = mock_writer
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = TensorBoardLogger(log_dir=tmpdir)
+            logger.finish()
+
+            mock_writer.flush.assert_called_once()
+            mock_writer.close.assert_called_once()

--- a/tests/test_logging_module/test_wandb.py
+++ b/tests/test_logging_module/test_wandb.py
@@ -159,3 +159,140 @@ class TestWandBLoggerMocked:
 
         call_kwargs = mock_wandb.init.call_args[1]
         assert call_kwargs["mode"] == "offline"
+
+    @patch("thinkrl.logging.wandb.wandb")
+    def test_log_artifact(self, mock_wandb):
+        """Test log_artifact method."""
+        mock_run = MagicMock()
+        mock_wandb.init.return_value = mock_run
+        mock_artifact = MagicMock()
+        mock_wandb.Artifact.return_value = mock_artifact
+
+        logger = WandBLogger(project="test")
+        logger.log_artifact(
+            name="my_model",
+            artifact_type="model",
+            path="/path/to/model.pt",
+            metadata={"accuracy": 0.95},
+        )
+
+        mock_wandb.Artifact.assert_called_once_with(
+            name="my_model",
+            type="model",
+            metadata={"accuracy": 0.95},
+        )
+        mock_artifact.add_file.assert_called_once_with("/path/to/model.pt")
+        mock_run.log_artifact.assert_called_once_with(mock_artifact)
+
+    @patch("thinkrl.logging.wandb.wandb")
+    def test_log_model(self, mock_wandb):
+        """Test log_model method (wraps log_artifact)."""
+        mock_run = MagicMock()
+        mock_wandb.init.return_value = mock_run
+        mock_artifact = MagicMock()
+        mock_wandb.Artifact.return_value = mock_artifact
+
+        logger = WandBLogger(project="test")
+        logger.log_model(
+            path="/path/to/model.pt",
+            name="checkpoint",
+            metadata={"epoch": 10},
+        )
+
+        mock_wandb.Artifact.assert_called_once_with(
+            name="checkpoint",
+            type="model",
+            metadata={"epoch": 10},
+        )
+
+    @patch("thinkrl.logging.wandb.wandb")
+    def test_run_property(self, mock_wandb):
+        """Test run property returns the run object."""
+        mock_run = MagicMock()
+        mock_run.name = "test-run"
+        mock_wandb.init.return_value = mock_run
+
+        logger = WandBLogger(project="test")
+        assert logger.run is mock_run
+
+    @patch("thinkrl.logging.wandb.wandb")
+    def test_log_hyperparams_without_run(self, mock_wandb):
+        """Test log_hyperparams does nothing when run failed."""
+        mock_wandb.init.side_effect = Exception("Failed")
+
+        logger = WandBLogger(project="test")
+        # Should not raise
+        logger.log_hyperparams({"lr": 1e-4})
+
+    @patch("thinkrl.logging.wandb.wandb")
+    def test_log_text_without_run(self, mock_wandb):
+        """Test log_text does nothing when run failed."""
+        mock_wandb.init.side_effect = Exception("Failed")
+
+        logger = WandBLogger(project="test")
+        # Should not raise
+        logger.log_text("key", "value", step=1)
+
+    @patch("thinkrl.logging.wandb.wandb")
+    def test_log_table_without_run(self, mock_wandb):
+        """Test log_table does nothing when run failed."""
+        mock_wandb.init.side_effect = Exception("Failed")
+
+        logger = WandBLogger(project="test")
+        # Should not raise
+        logger.log_table("key", ["a", "b"], [[1, 2]], step=1)
+
+    @patch("thinkrl.logging.wandb.wandb")
+    def test_log_artifact_without_run(self, mock_wandb):
+        """Test log_artifact does nothing when run failed."""
+        mock_wandb.init.side_effect = Exception("Failed")
+
+        logger = WandBLogger(project="test")
+        # Should not raise
+        logger.log_artifact("name", "type", "/path")
+
+    @patch("thinkrl.logging.wandb.wandb")
+    def test_finish_without_run(self, mock_wandb):
+        """Test finish does nothing when run failed."""
+        mock_wandb.init.side_effect = Exception("Failed")
+
+        logger = WandBLogger(project="test")
+        # Should not raise
+        logger.finish()
+
+    @patch("thinkrl.logging.wandb.wandb")
+    def test_init_with_all_params(self, mock_wandb):
+        """Test initialization with all parameters."""
+        mock_run = MagicMock()
+        mock_wandb.init.return_value = mock_run
+
+        WandBLogger(
+            project="test-project",
+            name="test-run",
+            config={"lr": 0.01},
+            tags=["tag1", "tag2"],
+            entity="my-team",
+            group="experiment-group",
+            notes="Test notes",
+            mode="online",
+            resume="allow",
+        )
+
+        call_kwargs = mock_wandb.init.call_args[1]
+        assert call_kwargs["project"] == "test-project"
+        assert call_kwargs["name"] == "test-run"
+        assert call_kwargs["entity"] == "my-team"
+        assert call_kwargs["group"] == "experiment-group"
+        assert call_kwargs["notes"] == "Test notes"
+        assert call_kwargs["resume"] == "allow"
+
+    @patch("thinkrl.logging.wandb.wandb")
+    def test_finish_sets_run_to_none(self, mock_wandb):
+        """Test finish sets _run to None."""
+        mock_run = MagicMock()
+        mock_wandb.init.return_value = mock_run
+
+        logger = WandBLogger(project="test")
+        assert logger._run is not None
+        logger.finish()
+        assert logger._run is None

--- a/tests/test_utils/test_agent.py
+++ b/tests/test_utils/test_agent.py
@@ -378,7 +378,7 @@ class NotAnAgent:
 
     def test_load_agent_class_not_subclass_warning(self, temp_agent_file_not_subclass, caplog):
         """Test warning when class is not a subclass of AgentInstanceBase."""
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.WARNING, logger="thinkrl.utils.agent"):
             AgentClass = load_agent_class(temp_agent_file_not_subclass, "NotAnAgent")
 
         assert AgentClass is not None

--- a/tests/test_utils/test_checkpoint.py
+++ b/tests/test_utils/test_checkpoint.py
@@ -253,12 +253,12 @@ class TestCheckpointEdgeCases:
         """Test saving checkpoint with extra state dictionary."""
         path = temp_dir / "extra_state.pt"
 
-        extra_state = {"custom_key": "custom_value", "step": 100}
-        save_checkpoint(path, simple_model, epoch=1, extra_state=extra_state)
+        # Extra kwargs are passed directly and saved at top level
+        save_checkpoint(path, simple_model, epoch=1, custom_key="custom_value", custom_step=100)
 
         loaded = load_checkpoint(path, simple_model)
         assert loaded.get("custom_key") == "custom_value"
-        assert loaded.get("step") == 100
+        assert loaded.get("custom_step") == 100
 
     def test_checkpoint_manager_mode_max(self, temp_dir, simple_model):
         """Test checkpoint manager with max mode."""

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -346,7 +346,7 @@ class TestLogging:
             content = f.read()
 
         assert "Epoch 1" in content
-        assert "100%" in content
+        assert "100.0%" in content
 
     def test_get_logger_returns_existing(self):
         """Test that get_logger returns existing configured logger."""

--- a/tests/test_utils/test_remote_rm_utils.py
+++ b/tests/test_utils/test_remote_rm_utils.py
@@ -109,7 +109,7 @@ class TestRemoteRewardModel:
     def test_init_no_source_warning(self, caplog):
         """Test warning when no source is provided."""
         import logging
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.WARNING, logger="thinkrl.utils.remote_rm_utils"):
             RemoteRewardModel()
 
         assert "No remote URLs or reward function specified" in caplog.text
@@ -125,7 +125,7 @@ class TestRemoteRewardModel:
         import logging
         rm = RemoteRewardModel()
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.WARNING, logger="thinkrl.utils.remote_rm_utils"):
             result = rm.get_rewards(["query1", "query2"])
 
         assert result == [0.0, 0.0]

--- a/tests/test_utils/test_seqlen_balancing.py
+++ b/tests/test_utils/test_seqlen_balancing.py
@@ -250,7 +250,7 @@ class TestLogSeqlenUnbalance:
         seqlen_list = [100, 50]
         partitions = [[0], [1]]
 
-        with caplog.at_level(logging.INFO):
+        with caplog.at_level(logging.INFO, logger="thinkrl.utils.seqlen_balancing"):
             log_seqlen_unbalance(
                 seqlen_list,
                 partitions,
@@ -302,7 +302,7 @@ class TestGetMinimumNumMicroBatchSize:
 
         total_lengths = [3000, 500]
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.WARNING, logger="thinkrl.utils.seqlen_balancing"):
             get_minimum_num_micro_batch_size(
                 total_lengths,
                 max_tokens_per_gpu=2048,

--- a/thinkrl/logging/tensorboard.py
+++ b/thinkrl/logging/tensorboard.py
@@ -53,6 +53,9 @@ class TensorBoardLogger(Logger):
             comment: Comment to append to log directory
             flush_secs: How often to flush to disk
         """
+        # Initialize _writer before potential ImportError so __del__ works
+        self._writer = None
+
         if not TENSORBOARD_AVAILABLE:
             raise ImportError(
                 "TensorBoard is not installed. Install with: pip install tensorboard"

--- a/thinkrl/logging/wandb.py
+++ b/thinkrl/logging/wandb.py
@@ -67,11 +67,13 @@ class WandBLogger(Logger):
             resume: Resume from run ID
             **kwargs: Additional wandb.init kwargs
         """
+        # Initialize _run before potential ImportError so __del__ works
+        self._run = None
+
         if not WANDB_AVAILABLE:
             raise ImportError("wandb is not installed. Install with: pip install wandb")
 
         self.project = project
-        self._run = None
 
         try:
             self._run = wandb.init(

--- a/thinkrl/utils/checkpoint.py
+++ b/thinkrl/utils/checkpoint.py
@@ -349,6 +349,50 @@ class CheckpointManager:
 
         return metadata
 
+    def load_latest_checkpoint(
+        self,
+        model: nn.Module,
+        optimizer: Optimizer | None = None,
+        scheduler: _LRScheduler | None = None,
+        device: torch.device | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Load the most recent checkpoint based on timestamp.
+
+        Args:
+            model: Model to load state into
+            optimizer: Optimizer to load state into (optional)
+            scheduler: Scheduler to load state into (optional)
+            device: Device to load tensors to
+
+        Returns:
+            Checkpoint metadata or None if no checkpoints exist
+        """
+        if not self.checkpoints:
+            logger.warning("No checkpoints available")
+            return None
+
+        # Sort by timestamp to find most recent
+        sorted_checkpoints = sorted(
+            self.checkpoints,
+            key=lambda x: x["timestamp"],
+            reverse=True,
+        )
+
+        latest = sorted_checkpoints[0]
+        checkpoint_path = latest["path"]
+
+        metadata = self.load_checkpoint(
+            checkpoint_path=checkpoint_path,
+            model=model,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            device=device,
+        )
+
+        logger.info(f"Loaded latest checkpoint: {checkpoint_path}")
+        return metadata
+
     def _update_best_checkpoint(self, checkpoint_info: dict[str, Any], metric_value: float):
         """Update the best checkpoint based on metric value."""
         if self.best_checkpoint is None:
@@ -663,7 +707,16 @@ def save_config(config: dict[str, Any], save_path: str | Path):
     save_path = Path(save_path)
     save_path.parent.mkdir(parents=True, exist_ok=True)
 
-    if save_path.suffix in [".yaml", ".yml"] and _YAML_AVAILABLE:
+    supported_extensions = [".json", ".yaml", ".yml"]
+    if save_path.suffix not in supported_extensions:
+        raise ValueError(
+            f"Unsupported config format: {save_path.suffix}. "
+            f"Supported formats: {supported_extensions}"
+        )
+
+    if save_path.suffix in [".yaml", ".yml"]:
+        if not _YAML_AVAILABLE:
+            raise ImportError("PyYAML is required to save YAML configs. Install with: pip install pyyaml")
         with open(save_path, "w") as f:
             yaml.dump(config, f, default_flow_style=False)
     else:
@@ -694,7 +747,16 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
     if not config_path.exists():
         raise FileNotFoundError(f"Config file not found: {config_path}")
 
-    if config_path.suffix in [".yaml", ".yml"] and _YAML_AVAILABLE:
+    supported_extensions = [".json", ".yaml", ".yml"]
+    if config_path.suffix not in supported_extensions:
+        raise ValueError(
+            f"Unsupported config format: {config_path.suffix}. "
+            f"Supported formats: {supported_extensions}"
+        )
+
+    if config_path.suffix in [".yaml", ".yml"]:
+        if not _YAML_AVAILABLE:
+            raise ImportError("PyYAML is required to load YAML configs. Install with: pip install pyyaml")
         with open(config_path) as f:
             config = yaml.safe_load(f)
     else:


### PR DESCRIPTION
- Fix TensorBoardLogger/WandBLogger __del__ AttributeError by initializing _writer/_run before potential ImportError in __init__
- Add pytest-asyncio configuration (asyncio_mode=auto) to pyproject.toml
- Fix caplog capture issues by specifying logger names in at_level()
- Add CheckpointManager.load_latest_checkpoint() method
- Add format validation to save_config/load_config for unsupported extensions
- Fix test assertions (100% -> 100.0%, extra_state access pattern)
- Add mocked tests for TensorBoardLogger and WandBLogger to improve coverage