### PR TITLE
Optimize tokenizer padding and log probability computation

### DIFF
--- a/thinkrl/cli/main.py
+++ b/thinkrl/cli/main.py
@@ -967,7 +967,7 @@ if TYPER_AVAILABLE:
         else:
             raise typer.Exit("Reference model is required (`--ref-model`)")
 
-        tokenizer = AutoTokenizer.from_pretrained(model)
+        tokenizer = AutoTokenizer.from_pretrained(model, padding_side="left")
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
 

--- a/thinkrl/models/actor.py
+++ b/thinkrl/models/actor.py
@@ -210,19 +210,17 @@ class Actor(nn.Module):
         if temperature != 1.0:
             logits = logits / temperature
 
-        # Compute log probabilities
-        log_probs = F.log_softmax(logits, dim=-1)
-
-        # Gather log probs for actual tokens (shifted by 1)
+        # Compute per-token log probabilities efficiently (avoids materializing [B, S, V] log_softmax)
         # logits[:, :-1] predicts tokens[:, 1:]
-        gathered_log_probs = (
-            log_probs[:, :-1, :]
-            .gather(
-                dim=-1,
-                index=input_ids[:, 1:].unsqueeze(-1),
-            )
-            .squeeze(-1)
-        )
+        shifted_logits = logits[:, :-1, :]  # [B, S-1, V]
+        shifted_labels = input_ids[:, 1:]   # [B, S-1]
+
+        # F.cross_entropy fuses log_softmax + gather internally, saving ~V*sizeof(float) per token
+        gathered_log_probs = -F.cross_entropy(
+            shifted_logits.reshape(-1, shifted_logits.size(-1)),
+            shifted_labels.reshape(-1),
+            reduction="none",
+        ).reshape(shifted_logits.size(0), shifted_logits.size(1))
 
         # Apply action mask if provided
         if action_mask is not None:


### PR DESCRIPTION
## Summary
This PR improves performance in two areas: tokenizer initialization and log probability computation during model inference.

## Key Changes
- **Tokenizer padding side**: Set `padding_side="left"` when loading the tokenizer in `reinforce_pp`. This ensures proper padding alignment for batch processing, which is important for causal language models where left-padding prevents attention to padding tokens.

- **Log probability computation optimization**: Refactored the log probability gathering in `actor.py` to use `F.cross_entropy` instead of manually computing `log_softmax` followed by `gather`. This leverages PyTorch's fused kernel implementation which:
  - Avoids materializing the full `[B, S, V]` log probability matrix in memory
  - Reduces memory usage by approximately `V * sizeof(float)` per token
  - Improves computational efficiency through kernel fusion
  - Produces mathematically equivalent results (negated cross-entropy equals log probability)

## Implementation Details
The log probability computation change replaces the explicit two-step process (log_softmax → gather) with `F.cross_entropy` in "none" reduction mode, which internally fuses these operations. The result is negated since cross-entropy loss is the negative log probability. The reshaping operations maintain compatibility with the rest of the forward pass.

https://claude.ai/code/session_012EcXuirdGQLLKo8FdMUkgx