### PR TITLE
docs(readme): update installation instructions for source install

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,18 @@ ThinkRL provides a full-stack solution for modern alignment:
 
 ### Installation
 
+> **Note**: ThinkRL is currently not available on PyPI. Please install from source.
+
 ```bash
-# Core installation
-pip install thinkrl
+# Clone the repository
+git clone https://github.com/ellanorai/ThinkRL.git
+cd ThinkRL
+
+# Install from source
+pip install -e .
 
 # With vLLM and DeepSpeed support (Recommended)
-pip install thinkrl[all]
+pip install -e .[all]
 ```
 
 ### Typical Workflow


### PR DESCRIPTION
- Add note that ThinkRL is not available on PyPI
- Replace pip install commands with clone and install from source
- Provide instructions for installing with vLLM and DeepSpeed support using editable installs
- Clarify installation steps to improve user setup experience