### PR TITLE
Refactor vLLM worker/client for production robustness and efficiency

### DIFF
--- a/tests/test_integration/test_vllm_client.py
+++ b/tests/test_integration/test_vllm_client.py
@@ -48,6 +48,13 @@ class TestVLLMClient:
             assert client.is_main_process is True
             assert client.url == "http://localhost:8000"
 
+    def test_init_with_timeouts(self):
+        # Test custom timeout configuration
+        with patch("torch.distributed.is_available", return_value=False):
+            client = VLLMClient(generate_timeout=60, control_timeout=10)
+            assert client.generate_timeout == 60
+            assert client.control_timeout == 10
+
     def test_init_distributed_rank1(self):
         # Test init on non-main process
         with patch("torch.distributed.is_available", return_value=True), patch(
@@ -82,6 +89,20 @@ class TestVLLMClient:
         assert kwargs["json"]["logprobs"] == 1
 
     @patch("requests.post")
+    def test_generate_has_timeout(self, mock_post, client):
+        """Test that generate passes timeout to requests.post."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"text": ["out"]}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        client.generate(["input"], params={}, return_logprobs=False)
+
+        args, kwargs = mock_post.call_args
+        assert "timeout" in kwargs
+        assert kwargs["timeout"] == client.generate_timeout
+
+    @patch("requests.post")
     def test_generate_error(self, mock_post, client):
         mock_post.side_effect = requests.RequestException("Connection refused")
 
@@ -113,8 +134,8 @@ class TestVLLMClient:
 
     @pytest.mark.skip(reason="Torch LIBRARY registration conflicts in test environment")
     @patch("requests.post")
-    def test_update_model_weights(self, mock_post, client):
-        # Mock HTTP call
+    def test_update_model_weights_flat_broadcast(self, mock_post, client):
+        """Test weight update uses flattened buffer broadcast."""
         mock_response = MagicMock()
         mock_response.raise_for_status.return_value = None
         mock_post.return_value = mock_response
@@ -123,13 +144,13 @@ class TestVLLMClient:
         mock_comm_instance = MagicMock()
         client.communicator = mock_comm_instance
 
-        # Create a simple model
+        # Create a simple model (Linear has weight + bias, both float32)
         model = torch.nn.Linear(1, 1)
 
         client.update_model_weights(model)
 
-        # Should broadcast twice (weight and bias)
-        assert mock_comm_instance.broadcast.call_count == 2
+        # With flattened broadcast, all float32 params are sent in one call
+        assert mock_comm_instance.broadcast.call_count == 1
 
     def test_update_model_weights_no_init(self, client):
         client.communicator = None
@@ -138,29 +159,23 @@ class TestVLLMClient:
 
     @pytest.mark.skip(reason="Torch LIBRARY registration conflicts in test environment")
     @patch("requests.post")
-    def test_update_model_weights_fsdp(self, mock_post, client):
-        """Test weight update triggers server sync and handles FSDP context."""
-        # Mock server response for /update_weights
+    def test_update_model_weights_triggers_server(self, mock_post, client):
+        """Test weight update triggers server sync via HTTP."""
         mock_response = MagicMock()
         mock_response.raise_for_status.return_value = None
         mock_post.return_value = mock_response
 
-        # Setup communicator mock
         mock_comm_instance = MagicMock()
         client.communicator = mock_comm_instance
 
-        # Create a simple model (not actually FSDP, but tests the path)
         model = torch.nn.Linear(1, 1)
-
         client.update_model_weights(model)
 
-        # Verify HTTP call to trigger server sync
+        # Verify HTTP call to trigger server sync with timeout
         mock_post.assert_called_once()
         args, kwargs = mock_post.call_args
         assert "/update_weights" in args[0]
-
-        # Verify broadcast called for both params
-        assert mock_comm_instance.broadcast.call_count == 2
+        assert "timeout" in kwargs
 
     def test_generate_no_logprobs(self, client):
         """Test generate when server doesn't return logprobs."""
@@ -175,3 +190,43 @@ class TestVLLMClient:
             assert result["text"] == ["output"]
             assert result["token_ids"] == []  # Fallback
             assert result["log_probs"] == []
+
+    @patch("requests.get")
+    def test_health_check_success(self, mock_get, client):
+        """Test health check returns True when server is healthy."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        assert client.health_check() is True
+        mock_get.assert_called_once()
+
+    @patch("requests.get")
+    def test_health_check_failure(self, mock_get, client):
+        """Test health check returns False when server is down."""
+        mock_get.side_effect = requests.RequestException("Connection refused")
+
+        assert client.health_check() is False
+
+    def test_health_check_non_main_process(self):
+        """Test health check is skipped on non-main process."""
+        with patch("torch.distributed.is_available", return_value=True), patch(
+            "torch.distributed.is_initialized", return_value=True
+        ), patch("torch.distributed.get_rank", return_value=1):
+            client = VLLMClient()
+            assert client.health_check() is True  # Always True for non-main
+
+    @patch("requests.post")
+    def test_shutdown_server(self, mock_post, client):
+        """Test shutdown_server sends POST to /shutdown."""
+        client.shutdown_server()
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert "/shutdown" in args[0]
+
+    @patch("requests.post")
+    def test_shutdown_server_when_down(self, mock_post, client):
+        """Test shutdown_server handles connection errors gracefully."""
+        mock_post.side_effect = requests.RequestException("Already down")
+        # Should not raise
+        client.shutdown_server()

--- a/thinkrl/algorithms/dapo.py
+++ b/thinkrl/algorithms/dapo.py
@@ -581,8 +581,12 @@ class DAPOAlgorithm(BaseRLHFAlgorithm):
         Returns:
             List of metrics dicts, one per epoch
         """
-        # Compute old_log_probs ONCE before any updates (θ_old frozen)
-        old_log_probs = self.compute_rollout_log_probs(batch)
+        # Use pre-computed old_log_probs if available (e.g. from vLLM),
+        # otherwise compute via forward pass (θ_old frozen)
+        if "old_log_probs" in batch:
+            old_log_probs = batch["old_log_probs"]
+        else:
+            old_log_probs = self.compute_rollout_log_probs(batch)
 
         all_metrics = []
         for epoch in range(self.config.n_epochs):

--- a/thinkrl/algorithms/dr_grpo.py
+++ b/thinkrl/algorithms/dr_grpo.py
@@ -260,8 +260,17 @@ class DrGRPOAlgorithm(BaseRLHFAlgorithm):
         return self.get_log_probs(outputs, batch["labels"])
 
     def train_on_rollout(self, rollout: dict[str, Any]) -> list[dict[str, Any]]:
-        """Train on collected rollout data."""
-        old_log_probs = self.compute_rollout_log_probs(rollout)
+        """Train on collected rollout data.
+
+        Args:
+            rollout: Rollout batch. May contain pre-computed "old_log_probs"
+                     from vLLM generation to avoid a redundant forward pass.
+        """
+        # Use pre-computed old_log_probs if available (e.g. from vLLM)
+        if "old_log_probs" in rollout:
+            old_log_probs = rollout["old_log_probs"]
+        else:
+            old_log_probs = self.compute_rollout_log_probs(rollout)
 
         epoch_metrics = []
         for epoch in range(self.config.n_epochs):

--- a/thinkrl/algorithms/grpo.py
+++ b/thinkrl/algorithms/grpo.py
@@ -334,9 +334,12 @@ class GRPOAlgorithm(BaseRLHFAlgorithm):
         Returns:
             List of metrics dicts, one per epoch
         """
-        # Freeze old policy distribution (Algorithm 1, Line 6/7 context)
-        # In this implementation, 'batch' corresponds to D_b sampled from pi_theta_old
-        old_log_probs = self.compute_rollout_log_probs(batch)
+        # Use pre-computed old_log_probs if available (e.g. from vLLM),
+        # otherwise compute via forward pass
+        if "old_log_probs" in batch:
+            old_log_probs = batch["old_log_probs"]
+        else:
+            old_log_probs = self.compute_rollout_log_probs(batch)
 
         epoch_metrics = []
         for epoch in range(self.config.n_epochs):

--- a/thinkrl/integration/vllm_client.py
+++ b/thinkrl/integration/vllm_client.py
@@ -1,11 +1,24 @@
 """
-ThinkRL vLLM Client (Improved)
-==============================
-Robust client for interacting with vLLM server with dynamic distributed support.
+ThinkRL vLLM Client
+===================
+
+Client for interacting with vLLM server with distributed training support.
 Handles Multi-GPU (DDP/FSDP) training environments correctly.
+
+Weight synchronization uses NCCL broadcast with flattened parameter buffers
+for efficient transfer. The protocol is:
+
+1. Client sends HTTP POST to /update_weights (server returns immediately,
+   spawns a background thread for NCCL receives)
+2. Client broadcasts flattened weight buffers grouped by dtype
+3. NCCL internally synchronizes sender/receiver
+
+This avoids the deadlock where the client waits for an HTTP response while
+the server waits for NCCL data.
 """
+
 import contextlib
-import importlib.util  # for checking availability
+import importlib.util
 import os
 from typing import Any
 
@@ -19,26 +32,40 @@ from thinkrl.utils.logging import get_logger
 try:
     if importlib.util.find_spec("vllm"):
         pass  # Imports verified inside methods to be safe
-except ImportError:
+except (ImportError, ValueError):
     pass
 
 logger = get_logger(__name__)
 
+# Default HTTP timeouts (seconds)
+_DEFAULT_GENERATE_TIMEOUT = 300  # 5 min for generation (large batches)
+_DEFAULT_CONTROL_TIMEOUT = 30  # 30s for control endpoints
+
 
 class VLLMClient:
-    def __init__(self, url: str = "http://localhost:8000", group_port: int = 51216, sync_world_size: int = 2):
+    def __init__(
+        self,
+        url: str = "http://localhost:8000",
+        group_port: int = 51216,
+        sync_world_size: int = 2,
+        generate_timeout: float = _DEFAULT_GENERATE_TIMEOUT,
+        control_timeout: float = _DEFAULT_CONTROL_TIMEOUT,
+    ):
         self.url = url
         self.group_port = group_port
         self.communicator = None
+        self._nccl_stream: torch.cuda.Stream | None = None
 
-        # We define the "Bridge" topology strictly
-        # Rank 0 = This Client (Trainer)
-        # Rank 1 = The vLLM Server
+        # Bridge topology: Rank 0 = Client (Trainer), Rank 1 = vLLM Server
         self.client_rank = 0
         self.server_rank = 1
         self.sync_world_size = sync_world_size
 
-        # Check if we are in a distributed training setup
+        # HTTP timeouts
+        self.generate_timeout = generate_timeout
+        self.control_timeout = control_timeout
+
+        # Distributed training info
         self.is_distributed = dist.is_available() and dist.is_initialized()
         self.is_main_process = True
         self.rank = 0
@@ -47,6 +74,17 @@ class VLLMClient:
             self.rank = dist.get_rank()
             # Only Rank 0 of the training cluster should talk to vLLM
             self.is_main_process = self.rank == 0
+
+    def health_check(self) -> bool:
+        """Check if vLLM server is reachable and healthy."""
+        if not self.is_main_process:
+            return True  # Non-main processes don't interact with server
+
+        try:
+            resp = requests.get(f"{self.url}/health", timeout=5)
+            return resp.status_code == 200
+        except requests.RequestException:
+            return False
 
     def generate(
         self,
@@ -76,13 +114,10 @@ class VLLMClient:
             return {"text": [], "token_ids": [], "log_probs": []}
 
         try:
-            # Request log_probs from vLLM to avoid double forward pass
             request_params = {**params}
             if return_logprobs:
-                # vLLM parameter: logprobs=N returns top N logprobs. We usually just need the performed action.
-                # However, vLLM returns a list of dicts. We set N=1 for efficiency.
                 request_params["logprobs"] = 1
-                request_params["prompt_logprobs"] = None  # Don't need prompt logprobs usually
+                request_params["prompt_logprobs"] = None
 
             resp = requests.post(
                 f"{self.url}/generate",
@@ -90,6 +125,7 @@ class VLLMClient:
                     "prompts": prompts,
                     **request_params,
                 },
+                timeout=self.generate_timeout,
             )
             resp.raise_for_status()
             result = resp.json()
@@ -100,7 +136,6 @@ class VLLMClient:
                 output["token_ids"] = result["token_ids"]
                 output["log_probs"] = result["log_probs"]
             elif return_logprobs:
-                # Fallback: server didn't return logprobs, caller will need to compute
                 logger.warning(
                     "vLLM server did not return log_probs. "
                     "Ensure server supports logprobs=1 parameter. "
@@ -117,8 +152,11 @@ class VLLMClient:
 
     def init_weight_sync(self, device: torch.device) -> None:
         """
-        Initializes the NCCL bridge.
+        Initialize the NCCL bridge for weight synchronization.
         Only the main training process initializes the communicator.
+
+        Creates a dedicated CUDA stream for NCCL operations to avoid
+        interfering with computation on the default stream.
         """
         if not self.is_main_process:
             return
@@ -127,17 +165,12 @@ class VLLMClient:
             from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
             from vllm.distributed.utils import StatelessProcessGroup
         except ImportError as e:
-            raise ImportError("vLLM is required for weight sync. Install with `pip install vllm`.") from e
+            raise ImportError(
+                "vLLM is required for weight sync. Install with `pip install vllm`."
+            ) from e
 
         logger.info(f"Initializing NCCL bridge on device {device} (Client Rank {self.client_rank})")
 
-        # Get server IP from URL if needed, usually passed separately or env var
-        # For now assume localhost or env var config for PyNccl
-        # PyNcclCommunicator mostly relies on 'host' being resolvable
-
-        # Create the Stateless Group for the Bridge
-        # This isolates the training traffic from the inference sync traffic
-        # Note: vLLM worker uses `socket.gethostbyname(socket.gethostname())` usually
         host = os.environ.get("VLLM_NCCL_HOST", "127.0.0.1")
 
         pg = StatelessProcessGroup.create(
@@ -145,12 +178,26 @@ class VLLMClient:
         )
 
         self.communicator = PyNcclCommunicator(pg, device=device)
+
+        # Dedicated CUDA stream for NCCL weight transfer
+        if isinstance(device, torch.device) and device.type == "cuda":
+            self._nccl_stream = torch.cuda.Stream(device=device)
+        elif isinstance(device, str) and "cuda" in device:
+            self._nccl_stream = torch.cuda.Stream(device=torch.device(device))
+
         logger.info("NCCL bridge initialized successfully.")
 
     def update_model_weights(self, model: torch.nn.Module) -> None:
         """
-        Broadcasts model weights to the vLLM server.
+        Broadcast model weights to the vLLM server.
         Handles FSDP/DDP contexts by ensuring we operate on the main process.
+
+        Protocol:
+        1. Send HTTP POST to /update_weights. The server returns immediately
+           after spawning a background thread that enters the NCCL receive loop.
+        2. Broadcast flattened weight buffers grouped by dtype. NCCL internally
+           synchronizes: the sender-side broadcast blocks until the receiver
+           has also called broadcast, so no explicit handshake is needed.
         """
         if not self.is_main_process:
             return
@@ -159,38 +206,68 @@ class VLLMClient:
             logger.error("Attempted to update weights without initialized communicator.")
             raise RuntimeError("Communicator not initialized. Call init_weight_sync() first.")
 
-        # 1. Trigger Server Sync
-        # We MUST tell the server to enter the recv loop.
+        # 1. Trigger server to enter receive mode.
+        #    The server endpoint returns immediately after spawning a background
+        #    NCCL receive task, breaking the deadlock where both sides wait.
         try:
-            resp = requests.post(f"{self.url}/update_weights")
+            resp = requests.post(
+                f"{self.url}/update_weights",
+                timeout=self.control_timeout,
+            )
             resp.raise_for_status()
         except requests.RequestException as e:
             logger.error(f"Failed to trigger weight update on server: {e}")
             raise RuntimeError(f"Weight update trigger failed: {e}") from e
 
-        # 2. Broadcast Weights
-        # logger.debug("Broadcasting model weights to vLLM server...")
-
-        # Handle FSDP: Gather full params on Rank 0
+        # 2. Broadcast weights using flattened buffers
         from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-        context = contextlib.nullcontext()
+        fsdp_ctx = contextlib.nullcontext()
         if isinstance(model, FSDP):
-            # Writeback=False because we just want to read for broadcast, not persist the gathering
-            context = FSDP.summon_full_params(model, writeback=False, rank0_only=True)
+            fsdp_ctx = FSDP.summon_full_params(model, writeback=False, rank0_only=True)
 
-        with context:
-            # Flatten parameters for efficient single-tensor broadcast
-            # This requires the server to know the structure to unflatten,
-            # OR we broadcast layer-by-layer.
-            # Layer-by-layer is slower but robust to architecture mismatches if handled by name.
-            # Flattening is much faster. Let's do flattening if possible, but for stability now,
-            # we will iterate. *Optimization: Bucket buffers.*
+        stream_ctx = (
+            torch.cuda.stream(self._nccl_stream)
+            if self._nccl_stream is not None
+            else contextlib.nullcontext()
+        )
 
-            # Simple iteration for v1 safety
-            for _, param in model.named_parameters():
-                # We strictly broadcast from Client (0) to Server (1)
-                # using the 'src' rank relative to the bridge group.
-                self.communicator.broadcast(param.data, src=self.client_rank)
+        with fsdp_ctx, stream_ctx:
+            self._broadcast_weights_flat(model)
 
-        return
+        # Synchronize NCCL stream before returning
+        if self._nccl_stream is not None:
+            self._nccl_stream.synchronize()
+
+    def _broadcast_weights_flat(self, model: torch.nn.Module) -> None:
+        """
+        Broadcast all model weights using flattened per-dtype buffers.
+
+        Groups parameters by dtype (preserving iteration order), flattens each
+        group into a single contiguous tensor, and broadcasts once per group.
+        This is significantly faster than per-parameter broadcast for models
+        with hundreds of parameters.
+
+        Both client and server must iterate model.named_parameters() in the same
+        order, which is guaranteed for the same model architecture.
+        """
+        # Group parameters by dtype, preserving insertion order
+        dtype_groups: dict[torch.dtype, list[torch.Tensor]] = {}
+        for _, param in model.named_parameters():
+            dt = param.data.dtype
+            if dt not in dtype_groups:
+                dtype_groups[dt] = []
+            dtype_groups[dt].append(param.data)
+
+        for _, params in dtype_groups.items():
+            flat = torch.cat([p.reshape(-1) for p in params])
+            self.communicator.broadcast(flat, src=self.client_rank)
+
+    def shutdown_server(self) -> None:
+        """Send a graceful shutdown signal to the vLLM server."""
+        if not self.is_main_process:
+            return
+        try:
+            requests.post(f"{self.url}/shutdown", timeout=5)
+        except requests.RequestException:
+            pass  # Server may already be down

--- a/thinkrl/integration/vllm_client.py
+++ b/thinkrl/integration/vllm_client.py
@@ -28,16 +28,16 @@ import torch.distributed as dist
 
 from thinkrl.utils.logging import get_logger
 
+logger = get_logger(__name__)
 
 try:
     if importlib.util.find_spec("vllm"):
         pass  # Imports verified inside methods to be safe
-except (ImportError, ValueError):
-    pass
-
-logger = get_logger(__name__)
+except (ImportError, ValueError) as exc:
+    logger.debug("vLLM module detection failed; treating 'vllm' as unavailable: %s", exc)
 
 # Default HTTP timeouts (seconds)
+_DEFAULT_GENERATE_TIMEOUT = 300  # 5 min for generation (large batches)
 _DEFAULT_GENERATE_TIMEOUT = 300  # 5 min for generation (large batches)
 _DEFAULT_CONTROL_TIMEOUT = 30  # 30s for control endpoints
 

--- a/thinkrl/integration/vllm_worker.py
+++ b/thinkrl/integration/vllm_worker.py
@@ -1,154 +1,320 @@
 """
-ThinkRL VLLM Worker
+ThinkRL vLLM Worker
 ===================
-Runs a VLLM engine that can receive weight updates from a training process via NCCL.
+
+Runs a vLLM engine that can receive weight updates from a training process
+via NCCL. Designed as a standalone FastAPI server.
+
+Key design decisions:
+- app.state instead of global mutable state
+- argparse in main() to avoid import-time side effects
+- asyncio.gather for multi-prompt generation (one engine.generate per prompt)
+- run_in_executor for blocking NCCL operations (avoids blocking the event loop)
+- Version-aware vLLM model access with multiple fallback paths
+- Flattened parameter buffers grouped by dtype for efficient weight transfer
+- /health and /metrics endpoints for observability
+- /shutdown endpoint for graceful termination
+- Configurable NCCL host via --nccl-host flag or VLLM_NCCL_HOST env var
 """
+
 import argparse
+import asyncio
+import contextlib
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
 import torch
 import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
 from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
 from vllm.distributed.utils import StatelessProcessGroup
 
 from thinkrl.utils.logging import get_logger
 
-
 logger = get_logger(__name__)
 
-# Global Engine
-engine: AsyncLLMEngine | None = None
-communicator: PyNcclCommunicator | None = None
-
-# Arguments
-parser = argparse.ArgumentParser()
-parser.add_argument("--model", type=str, required=True, help="Model path")
-parser.add_argument("--host", type=str, default="0.0.0.0")
-parser.add_argument("--port", type=int, default=8000)
-parser.add_argument("--group-port", type=int, default=51216)
-parser.add_argument("--gpu-memory-utilization", type=float, default=0.9)
-parser.add_argument("--dtype", type=str, default="auto")
-
-args, _ = parser.parse_known_args()
+# Thread pool for blocking NCCL operations (single worker to serialize syncs)
+_executor = ThreadPoolExecutor(max_workers=1)
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    # Startup
-    logger.info("Starting VLLM Engine...")
-    engine_args = AsyncEngineArgs(
-        model=args.model,
-        gpu_memory_utilization=args.gpu_memory_utilization,
-        dtype=args.dtype,
-        disable_log_requests=True,
-        enforce_eager=True,  # Required for weight updates often
+def _get_vllm_model(engine: AsyncLLMEngine):
+    """
+    Extract the underlying model from vLLM engine.
+
+    Tries multiple known internal access paths to handle version differences.
+    Supported: vLLM >= 0.4.0, < 1.0.0
+    """
+    access_paths = [
+        # vLLM >= 0.6.x
+        lambda e: e.engine.model_executor.driver_worker.model_runner.model,
+        # vLLM >= 0.5.x (alternative structure)
+        lambda e: e.engine.model_executor.model_runner.model,
+        # vLLM >= 0.4.x
+        lambda e: e.engine.driver_worker.model_runner.model,
+        # vLLM with GPU executor (some configs)
+        lambda e: e.engine.model_executor.driver_worker.worker.model_runner.model,
+    ]
+
+    for accessor in access_paths:
+        try:
+            model = accessor(engine)
+            if model is not None:
+                return model
+        except AttributeError:
+            continue
+
+    raise RuntimeError(
+        "Could not access vLLM internal model. "
+        "This may be due to an incompatible vLLM version. "
+        "Supported: vLLM >= 0.4.0, < 1.0.0"
     )
-    global engine
-    engine = AsyncLLMEngine.from_engine_args(engine_args)
 
-    # Initialize NCCL
-    # We are Rank 1 in the bridge group
-    logger.info("Initializing NCCL Bridge...")
+
+def _receive_weights(app: FastAPI) -> None:
+    """
+    Receive weight update from trainer via NCCL (runs in background thread).
+
+    Uses flattened parameter buffers grouped by dtype for efficient transfer.
+    Must match the client's broadcast order exactly (same model architecture,
+    same named_parameters() iteration order, same dtype grouping).
+    """
+    communicator = app.state.communicator
+    nccl_stream = app.state.nccl_stream
+    lock = app.state.weight_sync_lock
+
+    if not lock.acquire(timeout=600):
+        logger.error("Weight sync lock timeout - another sync may be stuck")
+        return
+
     try:
-        pg = StatelessProcessGroup.create(
-            host="127.0.0.1",  # Localhost for now, flexible later
-            port=args.group_port,
-            rank=1,
-            world_size=2,
+        model = _get_vllm_model(app.state.engine)
+
+        stream_ctx = (
+            torch.cuda.stream(nccl_stream)
+            if nccl_stream is not None
+            else contextlib.nullcontext()
         )
-        global communicator
-        communicator = PyNcclCommunicator(pg, device=torch.device("cuda:0"))
-    except Exception as e:
-        logger.error(f"Failed to init NCCL: {e}")
 
-    yield
-    # Shutdown
-    if communicator:
-        pass  # Cleanup if needed
+        with stream_ctx:
+            # Group parameters by dtype (same ordering as client)
+            dtype_groups: dict[torch.dtype, list[torch.nn.Parameter]] = {}
+            for _, param in model.named_parameters():
+                dt = param.data.dtype
+                if dt not in dtype_groups:
+                    dtype_groups[dt] = []
+                dtype_groups[dt].append(param)
 
+            for dtype, params in dtype_groups.items():
+                # Allocate flat receive buffer
+                total_size = sum(p.data.numel() for p in params)
+                flat = torch.empty(total_size, device=app.state.device, dtype=dtype)
 
-app = FastAPI(lifespan=lifespan)
+                # Receive from trainer (rank 0)
+                communicator.broadcast(flat, src=0)
 
+                # Unflatten into model parameters
+                offset = 0
+                for p in params:
+                    numel = p.data.numel()
+                    p.data.copy_(flat[offset : offset + numel].reshape(p.data.shape))
+                    offset += numel
 
-@app.post("/generate")
-async def generate(request: Request):
-    """Generate completion."""
-    data = await request.json()
-    prompts = data.get("prompts", [])
-    sampling_params_dict = {k: v for k, v in data.items() if k not in ["prompts"]}
-
-    sampling_params = SamplingParams(**sampling_params_dict)
-
-    results_generator = engine.generate(prompts, sampling_params, request_id=f"req_{id(data)}")
-
-    # We wait for the final result
-    final_output = []
-    async for request_output in results_generator:
-        final_output.append(request_output)
-
-    # Process output similar to vllm.entrypoints.api_server
-    # Simply returning text and logprobs
-    texts = []
-    token_ids = []
-    log_probs = []
-
-    for output in final_output:
-        # Assuming n=1
-        generated_text = output.outputs[0].text
-        texts.append(generated_text)
-
-        if output.outputs[0].token_ids:
-            token_ids.append(output.outputs[0].token_ids)
-
-        if output.outputs[0].logprobs:
-            # VLLM structure: list of dicts {token_id: logprob}
-            # We want just the logprob of the chosen token
-            seq_logprobs = []
-            for step_logprobs in output.outputs[0].logprobs:
-                # Top-1
-                if step_logprobs:
-                    top_token = list(step_logprobs.keys())[0]
-                    seq_logprobs.append(step_logprobs[top_token].logprob)
-            log_probs.append(seq_logprobs)
-
-    return JSONResponse({"text": texts, "token_ids": token_ids, "log_probs": log_probs})
-
-
-@app.post("/update_weights")
-async def update_weights():
-    """Trigger weight update from trainer."""
-    if not communicator:
-        return JSONResponse({"error": "NCCL not initialized"}, status_code=500)
-
-    logger.info("Receiving new weights...")
-
-    # We need to perform the NCCL recv on the model parameters
-    # This must match the order/structure of the sender
-    # We assume the engine model is available via engine.engine.model_executor.driver_worker.model_runner.model
-    # This acts on the *local* GPU model.
-
-    # Accessing the underlying model in vLLM is tricky and depends on version.
-    # For single-GPU vLLM, it's straightforward.
-    try:
-        # HACK: Access internal model. This is fragile.
-        # vLLM > 0.4.0 structure
-        model_executor = engine.engine.model_executor
-        model_runner = model_executor.driver_worker.model_runner
-        model = model_runner.model
-
-        for _, param in model.named_parameters():
-            communicator.broadcast(param.data, src=0)
+        if nccl_stream is not None:
+            nccl_stream.synchronize()
 
         logger.info("Weights updated successfully.")
-        return JSONResponse({"status": "ok"})
 
     except Exception as e:
-        logger.error(f"Update failed: {e}")
-        return JSONResponse({"error": str(e)}, status_code=500)
+        logger.error(f"Weight update failed: {e}")
+    finally:
+        lock.release()
+
+
+def create_app(args: argparse.Namespace) -> FastAPI:
+    """Create the FastAPI application with the given configuration."""
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        # Startup
+        logger.info("Starting vLLM Engine...")
+        engine_args = AsyncEngineArgs(
+            model=args.model,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            dtype=args.dtype,
+            disable_log_requests=True,
+            enforce_eager=True,  # Required for weight updates (disables CUDA graphs)
+        )
+        app.state.engine = AsyncLLMEngine.from_engine_args(engine_args)
+
+        # Initialize NCCL - we are Rank 1 in the bridge group
+        nccl_host = os.environ.get("VLLM_NCCL_HOST", args.nccl_host)
+        logger.info(f"Initializing NCCL Bridge (host={nccl_host}, port={args.group_port})...")
+        try:
+            pg = StatelessProcessGroup.create(
+                host=nccl_host,
+                port=args.group_port,
+                rank=1,
+                world_size=2,
+            )
+            device = torch.device(f"cuda:{args.gpu_id}")
+            app.state.communicator = PyNcclCommunicator(pg, device=device)
+            app.state.nccl_stream = torch.cuda.Stream(device=device)
+            app.state.device = device
+            logger.info("NCCL bridge initialized successfully.")
+        except Exception as e:
+            logger.error(f"Failed to init NCCL: {e}")
+            app.state.communicator = None
+            app.state.nccl_stream = None
+            app.state.device = torch.device(f"cuda:{args.gpu_id}")
+
+        app.state.weight_sync_lock = threading.Lock()
+        app.state.request_counter = 0
+
+        yield
+
+        # Shutdown
+        logger.info("Shutting down vLLM worker...")
+        _executor.shutdown(wait=True)
+
+    app = FastAPI(lifespan=lifespan)
+
+    @app.get("/health")
+    async def health():
+        """Health check endpoint."""
+        if not hasattr(app.state, "engine") or app.state.engine is None:
+            return JSONResponse({"status": "not_ready"}, status_code=503)
+        return JSONResponse({"status": "ok"})
+
+    @app.get("/metrics")
+    async def metrics():
+        """Basic metrics endpoint."""
+        return JSONResponse({
+            "requests_served": getattr(app.state, "request_counter", 0),
+        })
+
+    @app.post("/generate")
+    async def generate(request: Request):
+        """
+        Generate completions for one or more prompts.
+
+        Submits each prompt as a separate vLLM request and gathers results
+        concurrently via asyncio.gather.
+        """
+        engine = app.state.engine
+        data = await request.json()
+        prompts = data.pop("prompts", [])
+
+        # Build SamplingParams from remaining keys (filter None values)
+        sampling_params_dict = {k: v for k, v in data.items() if v is not None}
+        sampling_params = SamplingParams(**sampling_params_dict)
+
+        # Submit each prompt as a separate request and gather concurrently
+        async def _generate_single(prompt: str, req_id: str):
+            final = None
+            async for output in engine.generate(prompt, sampling_params, request_id=req_id):
+                final = output
+            return final
+
+        tasks = [
+            _generate_single(prompt, f"req_{app.state.request_counter}_{i}")
+            for i, prompt in enumerate(prompts)
+        ]
+        results = await asyncio.gather(*tasks)
+
+        app.state.request_counter += len(prompts)
+
+        texts = []
+        token_ids_list = []
+        log_probs_list = []
+
+        for output in results:
+            if output is None:
+                texts.append("")
+                continue
+
+            # Assuming n=1 (first completion)
+            completion = output.outputs[0]
+            texts.append(completion.text)
+
+            if completion.token_ids:
+                token_ids_list.append(list(completion.token_ids))
+
+            if completion.logprobs:
+                # Extract log probability of the chosen token at each step
+                seq_logprobs = []
+                for step_logprobs in completion.logprobs:
+                    if step_logprobs:
+                        top_token = next(iter(step_logprobs))
+                        seq_logprobs.append(step_logprobs[top_token].logprob)
+                log_probs_list.append(seq_logprobs)
+
+        return JSONResponse({
+            "text": texts,
+            "token_ids": token_ids_list,
+            "log_probs": log_probs_list,
+        })
+
+    @app.post("/update_weights")
+    async def update_weights():
+        """
+        Trigger weight update from trainer.
+
+        Returns immediately after spawning a background thread for NCCL
+        receives. The trainer then broadcasts weights, and NCCL synchronizes
+        the sender and receiver internally. This avoids a deadlock where the
+        client waits for the HTTP response while the server waits for NCCL data.
+        """
+        communicator = app.state.communicator
+        if not communicator:
+            return JSONResponse({"error": "NCCL not initialized"}, status_code=500)
+
+        logger.info("Weight update triggered, spawning receive task...")
+
+        # Launch the blocking NCCL receive in a background thread.
+        # run_in_executor submits to the ThreadPoolExecutor immediately;
+        # the thread starts independently of the event loop.
+        loop = asyncio.get_event_loop()
+        loop.run_in_executor(_executor, _receive_weights, app)
+
+        # Return immediately so client can proceed to broadcast
+        return JSONResponse({"status": "receiving"})
+
+    @app.post("/shutdown")
+    async def shutdown():
+        """Graceful shutdown endpoint."""
+        logger.info("Shutdown requested")
+        loop = asyncio.get_event_loop()
+        loop.call_later(1.0, lambda: os._exit(0))
+        return JSONResponse({"status": "shutting_down"})
+
+    return app
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ThinkRL vLLM Worker")
+    parser.add_argument("--model", type=str, required=True, help="Model path or HuggingFace model ID")
+    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--group-port", type=int, default=51216, help="Port for NCCL bridge")
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.9)
+    parser.add_argument("--dtype", type=str, default="auto")
+    parser.add_argument("--gpu-id", type=int, default=0, help="GPU device ID for this worker")
+    parser.add_argument(
+        "--nccl-host",
+        type=str,
+        default="127.0.0.1",
+        help="Host for NCCL bridge (overridden by VLLM_NCCL_HOST env var)",
+    )
+
+    args = parser.parse_args()
+
+    app = create_app(args)
+    uvicorn.run(app, host=args.host, port=args.port)
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host=args.host, port=args.port)
+    main()

--- a/thinkrl/training/reinforce_pp_trainer.py
+++ b/thinkrl/training/reinforce_pp_trainer.py
@@ -63,7 +63,6 @@ class ReinforcePPTrainer:
         self.vllm_client = None
 
         # Setup generation config
-        # Setup generation config
         num_return_sequences = 1
         if config and config.mode == "baseline":
             num_return_sequences = config.group_size
@@ -171,14 +170,6 @@ class ReinforcePPTrainer:
                         expanded_prompts.extend([p] * num_return_sequences)
                     prompts_text = expanded_prompts
 
-                # Expand prompts if needed for reward fn
-                num_return_sequences = self.generation_config.num_return_sequences
-                if num_return_sequences > 1:
-                    expanded_prompts = []
-                    for p in prompts_text:
-                        expanded_prompts.extend([p] * num_return_sequences)
-                    prompts_text = expanded_prompts
-
                 # Extract and expand targets if available
                 targets = batch_prompts.get("target", None)
                 kwargs = {}
@@ -242,15 +233,17 @@ class ReinforcePPTrainer:
         # Expand prompts if generating multiple sequences per prompt
         num_return_sequences = self.generation_config.num_return_sequences
         if num_return_sequences > 1:
-            # Replicate prompts: [p1, p2] -> [p1, p1, p2, p2]
             expanded_prompts = []
             for p in prompts_text:
                 expanded_prompts.extend([p] * num_return_sequences)
             prompts_text = expanded_prompts
 
+            # Also expand input_ids and attention_mask to match
+            input_ids = input_ids.repeat_interleave(num_return_sequences, dim=0)
+            attention_mask = attention_mask.repeat_interleave(num_return_sequences, dim=0)
+
         if self.use_vllm:
             # --- VLLM Generation ---
-            # Extract generation params
             params = {
                 "max_tokens": self.generation_config.max_new_tokens,
                 "temperature": self.generation_config.temperature,
@@ -261,83 +254,73 @@ class ReinforcePPTrainer:
 
             completions_text = output["text"]
             token_ids_list = output["token_ids"]
-            log_probs_list = output["log_probs"]  # List of list of floats
+            log_probs_list = output["log_probs"]
 
-            # Need to convert these lists back to tensors and pad them
-            # And crucially, reconstruct the full sequence input_ids + generated_ids
-            # This is complex because lengths vary.
-
-            # For simplicity, we assume we need to return padded tensors similar to local gen
+            # Convert token ID lists to tensors and pad
             generated_ids = [torch.tensor(ids, dtype=torch.long, device=self.device) for ids in token_ids_list]
             generated_ids_padded = torch.nn.utils.rnn.pad_sequence(
                 generated_ids, batch_first=True, padding_value=self.tokenizer.pad_token_id
             )
 
-            # Construct full sequences
-            # Note: input_ids might be padded on left or right. Standard HF is right padded usually for Enc,
-            # but for Gen usually Left padded. The collator right-padded everything.
-            # We need to concatenate carefully.
-
-            # Ideally, we re-tokenize the prompt + completion to get clean full sequences
-            # But we can also just concat.
+            # Build full sequences, labels, and aligned old_log_probs
             full_sequences = []
             labels = []
             old_log_probs_list = []
+            has_valid_logprobs = bool(log_probs_list) and all(len(lp) > 0 for lp in log_probs_list)
 
             for i in range(len(prompts_text)):
-                # Reconstruct per sample
-                # input_len = len(batch_prompts["input_ids"][i]) - padding
-                # Simplest: just use the valid tokens
+                # Get unpadded prompt tokens
                 curr_input_ids = input_ids[i][attention_mask[i] == 1]
                 curr_gen_ids = generated_ids[i]
 
                 curr_full = torch.cat([curr_input_ids, curr_gen_ids])
                 full_sequences.append(curr_full)
 
-                # Labels: -100 for prompt
+                # Labels: -100 for prompt tokens
                 curr_labels = curr_full.clone()
                 curr_labels[: len(curr_input_ids)] = -100
                 labels.append(curr_labels)
 
-                # Old Log Probs:
-                # We have log probs for the generated part.
-                # We need to construct a tensor matching the generated part.
-                curr_log_probs = torch.tensor(log_probs_list[i], dtype=torch.float, device=self.device)
-                old_log_probs_list.append(curr_log_probs)
+                # Construct aligned old_log_probs for the full sequence.
+                # The algorithm's get_log_probs() applies a causal shift: logits[t]
+                # predicts labels[t+1], so log_probs[t] = log P(token[t+1] | context[0:t]).
+                # After the shift, generated token logprobs start at position
+                # (num_prompt_tokens - 1) in the output tensor. vLLM's logprobs[k]
+                # is the log prob of generating the k-th token, matching this alignment.
+                if has_valid_logprobs:
+                    curr_log_probs = torch.tensor(
+                        log_probs_list[i], dtype=torch.float, device=self.device
+                    )
+                    full_log_probs = torch.zeros(len(curr_full), device=self.device)
+                    num_prompt_tokens = len(curr_input_ids)
+                    start_pos = num_prompt_tokens - 1
+                    end_pos = min(start_pos + len(curr_log_probs), len(full_log_probs))
+                    use_len = end_pos - start_pos
+                    full_log_probs[start_pos:end_pos] = curr_log_probs[:use_len]
+                    old_log_probs_list.append(full_log_probs)
 
             # Pad everything
             full_sequences_padded = torch.nn.utils.rnn.pad_sequence(
                 full_sequences, batch_first=True, padding_value=self.tokenizer.pad_token_id
             )
             labels_padded = torch.nn.utils.rnn.pad_sequence(labels, batch_first=True, padding_value=-100)
-            # Log probs need padding?
-            # The algorithm expects log_probs for the *generated* part usually, aligned with actions.
-            # REINFORCEPPAlgorithm.get_log_probs expects (logits, labels) usually.
-            # But we are bypassing the forward pass for old_log_probs.
-            # If we pass old_log_probs explicitly, the algorithm must handle it.
-            # Standard REINFORCEPPAlgorithm computes it internally if not provided.
-            # We need to ensure REINFORCEPPAlgorithm accepts pre-computed old_log_probs.
-            # Checking `reinforce_pp.py` ... it likely computes it.
-            # If we want to optimize, we should modify the algorithm to accept it.
-            # For now, let's just return what we have.
 
-            # To avoid modifying `reinforce_pp.py` right now, we can just ignore VLLM logprobs
-            # and recompute them in `train_on_rollout` (Standard PPO approach),
-            # BUT user asked for "everything", implying optimization.
-            # Let's assume we recompute for safety, as VLLM logprobs are sometimes slightly diff from Train-mode model.
-
-            # Correction: User wants VLLM integration.
-            # I will return the basic data. The algorithm will likely run a forward pass
-            # to get the gradient flow anyway.
-
-            return {
+            result = {
                 "input_ids": full_sequences_padded,
                 "attention_mask": (full_sequences_padded != self.tokenizer.pad_token_id).long(),
                 "labels": labels_padded,
                 "generated_ids": generated_ids_padded,
                 "completions_text": completions_text,
-                # "old_log_probs": ... (Optional optimization)
             }
+
+            # Include pre-computed old_log_probs if vLLM returned valid logprobs.
+            # This avoids a redundant forward pass in train_on_rollout().
+            if has_valid_logprobs and old_log_probs_list:
+                result["old_log_probs"] = torch.nn.utils.rnn.pad_sequence(
+                    old_log_probs_list, batch_first=True, padding_value=0.0
+                )
+
+            return result
 
         else:
             # --- Local Generation ---


### PR DESCRIPTION
## Summary

This PR significantly improves the vLLM integration for distributed training by refactoring the worker and client for production robustness, adding observability, and optimizing weight synchronization. The changes enable efficient multi-GPU training with proper NCCL synchronization and graceful error handling.

## Key Changes

### vLLM Worker (`vllm_worker.py`)
- **Restructured as production FastAPI service**: Moved from module-level globals to proper app state management via `app.state`, eliminating import-time side effects
- **Added observability endpoints**: `/health` for readiness checks and `/metrics` for request counting
- **Graceful shutdown**: New `/shutdown` endpoint for clean termination
- **Fixed NCCL deadlock**: Refactored `/update_weights` to spawn background thread for NCCL receives, allowing HTTP response to return immediately before weight broadcast (prevents client/server mutual blocking)
- **Optimized weight transfer**: Implemented flattened parameter buffers grouped by dtype for efficient single-tensor broadcast per dtype instead of per-parameter
- **Version-aware model access**: Added `_get_vllm_model()` with multiple fallback paths to handle vLLM version differences (0.4.x through 0.6.x+)
- **Dedicated NCCL stream**: Uses separate CUDA stream for weight transfers to avoid interfering with inference
- **Thread-safe weight sync**: Added `threading.Lock` to serialize concurrent weight updates
- **Configurable NCCL host**: Support for `--nccl-host` flag and `VLLM_NCCL_HOST` environment variable
- **Concurrent prompt generation**: Uses `asyncio.gather()` for multi-prompt requests instead of sequential processing
- **Proper argument parsing**: Moved to `main()` function to avoid import-time side effects

### vLLM Client (`vllm_client.py`)
- **Configurable HTTP timeouts**: Added separate `generate_timeout` (300s) and `control_timeout` (30s) parameters for different operation types
- **Health check method**: New `health_check()` to verify server availability before operations
- **Flattened weight broadcast**: Implemented `_broadcast_weights_flat()` to group parameters by dtype and broadcast as single tensors per dtype (significantly faster for large models)
- **Dedicated NCCL stream**: Creates separate CUDA stream for weight transfers
- **Improved FSDP handling**: Proper context management for full parameter gathering in distributed settings
- **Better error messages**: More informative logging for NCCL initialization and weight sync failures
- **Protocol documentation**: Added detailed comments explaining the async HTTP + NCCL synchronization pattern

### Training Integration (`reinforce_pp_trainer.py`, `dr_grpo.py`, `grpo.py`, `dapo.py`)
- **Pre-computed log probabilities**: Modified training algorithms to accept pre-computed `old_log_probs` from vLLM generation, avoiding redundant forward passes
- **Proper sequence expansion**: Fixed prompt expansion for multi-sequence generation to also expand input_ids and attention_mask tensors
- **Aligned log probability handling**: Corrected alignment of vLLM-generated log probabilities with full sequences using causal shift semantics

### Tests (`test_vllm_client.py`)
- Added timeout configuration tests
- Added health check tests (success and failure cases)
- Updated weight update tests to verify flattened broadcast behavior (single call for same-dtype parameters)
- Added HTTP timeout verification tests

## Notable Implementation Details

1. **NCCL Deadlock Prevention**: The `/update_weights` endpoint returns immediately after spawning a background thread. This breaks the deadlock where both client and server wait for each other—the client can proceed to broadcast while the server's background thread waits for NCCL data.

2. **Flattened Buffer Efficiency**: Instead of broadcasting each parameter individually (hundreds of calls for large models), parameters are grouped by dtype and flattened into single tensors. This reduces NCCL overhead significantly.

3. **Version Compatibility**: The `_get_vllm_model()` function tries multiple internal access paths to handle vLLM API changes across versions, with clear error messages if none work.

https://claude.ai/code/session_01GJT242Kao1jHsJfsRDA48Z