### PR TITLE
feat: Add a new CLI command for Group Relative Policy Optimization(GRPO)

### DIFF
--- a/thinkrl/cli/grpo.py
+++ b/thinkrl/cli/grpo.py
@@ -56,6 +56,7 @@ def grpo(
         str | None, Option("--reward-fn", help="Path to reward function (module.py:func_name)")
     ] = None,
     deepspeed: Annotated[str | None, Option("--deepspeed", help="Path to DeepSpeed configuration file")] = None,
+    local_rank: Annotated[int, Option("--local_rank", "--local-rank", hidden=True)] = -1,
     use_vllm: Annotated[str, Option("--use-vllm", help="Use VLLM for generation (true/false)")] = "false",
     vllm_group_port: Annotated[int, Option("--vllm-group-port", help="NCCL group port for VLLM sync")] = 51216,
     gradient_checkpointing: Annotated[


### PR DESCRIPTION
This PR introduces the new `grpo` training command to the ThinkRL CLI, enabling Group Relative Policy Optimization training with native support for LoRA, vLLM, and WandB logging.

It also resolves several core CLI parsing bugs that prevented proper argument handling in the routing layer.

### Key Changes
* **Added `grpo` CLI Endpoint**: Full integration of the `GRPOTrainer` into the CLI accessible via `thinkrl grpo` and `grpo`.
* **Fixed Typer Namespace Bug**: Resolved an issue in `thinkrl/cli/main.py` where `add_typer()` was accidentally creating a nested subcommand namespace (`grpo grpo --model`), hiding arguments. The command is now mounted directly to the root CLI using decorators.
* **Fixed Boolean Parameter Parsing**: Removed Typer's deprecated `is_flag` logic which was falsely parsing standard string tags (like `--use-vllm false`) as positional arguments causing `unexpected extra argument` crashes. 
* **Added Support for DeepSpeed Auto-Arguments**: Added hidden `--local_rank` parameter handling to `grpo.py` to natively support process launching via DeepSpeed.