### PR TITLE
Fail loudly instead of completing a GRPO run that did nothing

### DIFF
--- a/thinkrl/cli/grpo.py
+++ b/thinkrl/cli/grpo.py
@@ -121,6 +121,10 @@ def grpo(
         bf16 = False
         typer.echo("Note: Both BF16 and FP16 requested. Prioritizing FP16 (BF16 disabled).")
 
+    if not ref_model:
+        typer.echo("Error: a reference model is required (`--ref-model`).", err=True)
+        raise typer.Exit(code=1)
+
     from thinkrl.algorithms.grpo import GRPOConfig
     from thinkrl.data.datasets import RLHFDataset
     from thinkrl.models.loader import get_model
@@ -149,19 +153,16 @@ def grpo(
         policy_model.gradient_checkpointing_enable()
         typer.echo("Gradient checkpointing enabled for policy model.")
 
-    if ref_model:
-        ref_model_inst = get_model(
-            ref_model,
-            model_type="ref",
-            bf16=bf16,
-            fp16=fp16,
-            trust_remote_code=True,
-            lora_init_type=lora_init,
-            use_flash_attention=use_flash_attention,
-            device_map={"": local_rank} if torch.cuda.is_available() else None,
-        )
-    else:
-        raise typer.Exit("Reference model is required (`--ref-model`)")
+    ref_model_inst = get_model(
+        ref_model,
+        model_type="ref",
+        bf16=bf16,
+        fp16=fp16,
+        trust_remote_code=True,
+        lora_init_type=lora_init,
+        use_flash_attention=use_flash_attention,
+        device_map={"": local_rank} if torch.cuda.is_available() else None,
+    )
 
     tokenizer = AutoTokenizer.from_pretrained(model, padding_side="left")
     if tokenizer.pad_token is None:
@@ -247,6 +248,14 @@ def grpo(
     per_device_train_batch_size = int(per_device_train_batch_size)
     dataset_len = int(len(train_dataset))
     total_steps = num_train_epochs * dataset_len // per_device_train_batch_size
+    if total_steps == 0:
+        typer.echo(
+            f"Error: {dataset_len} samples over {num_train_epochs} epoch(s) at batch size "
+            f"{per_device_train_batch_size} gives 0 training steps. Lower --batch-size or "
+            f"raise --max-samples.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
     trainer.train(steps=total_steps, batch_size=per_device_train_batch_size)
 
     typer.echo("Training complete.")

--- a/thinkrl/training/grpo_trainer.py
+++ b/thinkrl/training/grpo_trainer.py
@@ -179,12 +179,25 @@ class GRPOTrainer:
 
                 rewards = self.reward_fn(prompts_text, completions_text, **kwargs).to(self.device)
 
-                # Trim if batch size mismatch
-                curr_bs = len(prompts_text)
+                curr_bs = len(completions_text)
                 if rewards.shape[0] != curr_bs:
-                    rewards = rewards[:curr_bs]
+                    raise ValueError(
+                        f"reward_fn returned {rewards.shape[0]} rewards for {curr_bs} "
+                        f"completions. It must return exactly one reward per completion, "
+                        f"in prompt-major order ({len(batch_prompts['prompt_text'])} prompts "
+                        f"x {num_return_sequences} samples)."
+                    )
 
                 rollout_data["rewards"] = rewards
+
+                grouped = rewards.view(-1, num_return_sequences)
+                dead = int((grouped.std(dim=1, unbiased=False) == 0).sum())
+                if dead:
+                    logger.warning(
+                        f"Step {step}: {dead}/{grouped.shape[0]} groups have zero reward "
+                        f"variance, so they contribute no gradient. The reward function may "
+                        f"not be discriminating between completions."
+                    )
 
                 # 3. Train Step
                 # Executes the GRPO Inner Loop via `train_on_rollout`, computing group-relative


### PR DESCRIPTION
Closes #64.

A GRPO run currently reports success after doing no work. `cli/grpo.py` computes `total_steps = num_train_epochs * len(dataset) // per_device_train_batch_size`, which floors to zero whenever the dataset is smaller than one batch. The training loop is then skipped entirely, "Training complete." is printed, an untrained checkpoint is written, and the process exits 0. The most common way to reach this is not an unusual batch size but a `--prompt-column` that does not match the dataset, since `RLHFDataset` only logs a warning when every row is filtered out and returns an empty dataset.

This change validates the step count before training starts and exits with a clear message naming the three values involved. It also checks the reward function's output length against the completion count rather than silently truncating or padding it, so a wrong shape is reported against the reward function instead of surfacing later as a batching error, and it warns with a count when groups have zero reward variance, which produces no gradient and is otherwise indistinguishable from healthy training.

Verified against a CPU fixture. Before this change, `--batch-size 32 --max-samples 8` prints "Training complete.", saves a checkpoint and exits 0. After it, the run exits 1 with `Error: 8 samples over 1 epoch(s) at batch size 32 gives 0 training steps. Lower --batch-size or raise --max-samples.` and writes no checkpoint. The full test suite is unchanged from `main` at 738 passed, and `ruff check .` reports the same count as `main`.

@Archit03 happy to adjust the wording or the failure mode if you would prefer a warning over a hard exit.
