### PR TITLE
Correct GRPO status and reward function contract in the README, add a GRPO guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ See `examples/` for detailed scripts:
 ## 📊 Implementation Status
 
 ### ✅ Production-Ready
-- **Core Algorithms**: PPO, GRPO, DPO, IPO, VAPO, DAPO, COPO, REINFORCE++
+- **Algorithm implementations**: PPO, GRPO, DPO, IPO, VAPO, DAPO, COPO, REINFORCE++
+  (implemented and unit tested; see Training Loops below for which have a working CLI)
 - **Models**: Actor, Critic, Reward Model, Process Reward Model (PRM)
 - **Loss Functions**: Comprehensive loss module with 15+ implementations
 - **Distributed Training**: DeepSpeed integration (ZeRO-2/3), distributed utilities
@@ -217,7 +218,10 @@ See `examples/` for detailed scripts:
 - **vLLM Integration**: High-throughput generation client/worker
 
 ### 🚧 In Development
-- **Training Loops**: GRPO CLI commands and Standalone scripts are fully Production-Ready. SFT, DPO, PPO are in progress.
+- **Training Loops**: REINFORCE++ is the only algorithm validated end to end against
+  accuracy benchmarks. GRPO and STaR have working CLI commands that train, but have not
+  been benchmark validated. SFT, DPO, PPO, ORPO, KTO and reward model training are not
+  yet implemented and their CLI commands exit with an error.
 - **CoT/ToT Trainers**: Chain-of-Thought and Tree-of-Thought training modules
 - **Multimodal Training**: PAPO implementation for vision-language models
 - **Complete Examples**: End-to-end training scripts
@@ -235,18 +239,35 @@ See `examples/` for detailed scripts:
 ### Custom Reward Functions
 ThinkRL supports plug-and-play reward functions for specialized domains (coding, math):
 
+A reward function receives every completion in the batch and returns one reward per
+completion, in prompt-major order:
+
 ```python
-def math_reward(completion, answer):
-    # Custom logic
-    return 1.0 if verify_math(completion, answer) else 0.0
+# my_reward.py
+import torch
+
+def reward_fn(prompts: list[str], completions: list[str], **kwargs) -> torch.Tensor:
+    """kwargs contains 'targets' when --target-column is set."""
+    targets = kwargs.get("targets") or [None] * len(completions)
+    return torch.tensor(
+        [1.0 if t and t in c else 0.0 for c, t in zip(completions, targets)],
+        dtype=torch.float,
+    )
 ```
+
+```bash
+thinkrl grpo ... --reward-fn my_reward.py:reward_fn
+```
+
+The bundled `UniversalReward` covers math, code and `<think>`/`<answer>` structure
+checking; see `my_reward.py` in the repository root for a ready-made configuration.
 
 ### LoRA Merging
 ```bash
-python -m thinkrl.cli.merge_lora \
-    --base_model meta-llama/Llama-3-8b \
-    --lora_path ./checkpoints/final_lora \
-    --output_path ./exported_model
+thinkrl merge \
+    --base-model meta-llama/Llama-3-8b \
+    --adapter ./checkpoints/final_lora \
+    --output ./exported_model
 ```
 
 ---

--- a/docs/grpo.md
+++ b/docs/grpo.md
@@ -1,0 +1,224 @@
+# GRPO Training Guide
+
+Group Relative Policy Optimization, as described in
+[DeepSeekMath](https://arxiv.org/abs/2402.03300), Appendix A.1.6.
+
+GRPO removes the critic used by PPO. For each prompt it samples a group of `G` completions,
+normalizes their rewards within the group to obtain advantages, and optimizes a PPO-style
+clipped surrogate with a direct KL penalty against a frozen reference model.
+
+> **Status**: the CLI trains end to end, but GRPO has not been validated against accuracy
+> benchmarks. Treat results as unverified. REINFORCE++ is the validated algorithm.
+
+## Quick Start
+
+```bash
+# Activate your environment
+source .venv/bin/activate
+
+# Basic training command
+thinkrl grpo \
+    --model Qwen/Qwen2.5-0.5B-Instruct \
+    --ref-model Qwen/Qwen2.5-0.5B-Instruct \
+    --dataset openai/gsm8k \
+    --dataset-config main \
+    --prompt-column question \
+    --target-column answer \
+    --group-size 8 \
+    --batch-size 2 \
+    --reward-fn my_reward.py:reward_fn
+```
+
+A reference model is required. GRPO's KL penalty is computed against it, and the command
+exits with an error if `--ref-model` is omitted.
+
+## Installation
+
+```bash
+git clone https://github.com/ellanorai/ThinkRL.git
+cd ThinkRL
+
+python -m venv .venv
+source .venv/bin/activate
+
+pip install -e .
+```
+
+A CUDA GPU is required. The dependency set includes CUDA-only packages and the training
+loop holds a policy model, a reference model, and a full group of rollouts at once.
+
+## CLI Reference
+
+### Required Arguments
+
+| Flag | Description |
+| --- | --- |
+| `--model`, `-m` | Policy model name or path |
+| `--ref-model`, `-r` | Reference model for the KL penalty |
+| `--dataset`, `-d` | Prompt dataset name or path |
+
+### Dataset Arguments
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--source`, `-s` | `hf` | One of `hf`, `local`, `json`, `csv` |
+| `--dataset-split` | `train` | Split to load |
+| `--dataset-config` | `None` | Config name, for example `main` for gsm8k |
+| `--prompt-column`, `-pc` | `prompt` | Column holding the prompt |
+| `--target-column` | `answer` | Column holding the reference answer |
+| `--max-samples` | all | Cap on samples loaded |
+| `--max-length` | `512` | Maximum prompt length in tokens |
+| `--system-prompt` | reasoning preset | Prepended to every prompt |
+
+`--max-length` truncates the prompt only. Completion length is currently fixed at 256 new
+tokens and is not exposed on the command line.
+
+### Training Arguments
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--group-size`, `-g` | `64` | Completions sampled per prompt (`G`) |
+| `--batch-size`, `-b` | `4` | Prompts per device per step |
+| `--epochs` | `1` | Passes over the dataset |
+| `--learning-rate`, `--lr` | `1e-6` | Optimizer learning rate |
+| `--kl-coeff` | `0.04` | KL penalty coefficient (`beta`) |
+| `--grad-accum`, `-ga` | `1` | Gradient accumulation steps |
+
+Each step generates `batch_size * group_size` sequences. The defaults produce 256
+sequences per step, which will not fit on a single consumer GPU. Start with
+`--group-size 8 --batch-size 2` and increase from there.
+
+The step count is `epochs * dataset_size // batch_size`. If that evaluates to zero the
+command exits with an error rather than reporting a completed run.
+
+### LoRA Arguments
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--lora-r` | `None` | LoRA rank; LoRA is enabled when set |
+| `--lora-init` | `default` | One of `default`, `garbage`, `pissa`, `pissa_niter_[n]` |
+
+### Optimization Arguments
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--bf16` / `--no-bf16` | `--bf16` | bfloat16 precision |
+| `--fp16` / `--no-fp16` | `--no-fp16` | float16 precision; takes priority over bf16 |
+| `--flash-attn` / `--no-flash-attn` | `--no-flash-attn` | Flash Attention 2 |
+| `--gradient-checkpointing` | off | Trade compute for memory |
+| `--deepspeed` | `None` | Path to a DeepSpeed config, for example `configs/ds_zero2.json` |
+
+### Logging Arguments
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--logging-backend` | `tensorboard` | One of `tensorboard`, `wandb`, `none` |
+| `--wandb-project` | `thinkrl-grpo` | W&B project name |
+| `--output-dir`, `-o` | `./grpo_output` | Where the trained model is written |
+
+With `--logging-backend wandb` the following are recorded each step: `train/loss`,
+`train/reward_mean`, `train/reward_std`, `train/kl_mean`, `train/advantage_mean`,
+`train/clip_fraction`, `train/grad_norm`, `train/epoch`.
+
+### Advanced Arguments
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--use-vllm` | `false` | Use a vLLM server for generation; accepts `true` or `false` |
+| `--vllm-group-port` | `51216` | NCCL group port for weight synchronization |
+| `--dry-run` | off | Build models, dataset and trainer, then exit before training |
+
+The vLLM server address is currently fixed at `http://localhost:8000` and the weight
+synchronization group is fixed at one trainer rank plus one server.
+
+## Reward Functions
+
+### Using the Universal Reward
+
+`UniversalReward` handles numerical equivalence for math, markdown block extraction for
+code, normalized string matching for text, and `<think>...</think><answer>...</answer>`
+structure validation. The repository root contains a ready-made configuration:
+
+```bash
+thinkrl grpo ... --reward-fn my_reward.py:reward_fn
+```
+
+### Custom Reward Functions
+
+```python
+# my_reward.py
+import torch
+
+def reward_fn(prompts: list[str], completions: list[str], **kwargs) -> torch.Tensor:
+    """
+    Args:
+        prompts: One entry per completion, repeated group_size times per prompt.
+        completions: The generated text.
+        **kwargs: Contains 'targets' when --target-column is set, aligned with completions.
+
+    Returns:
+        One reward per completion, in the same order as `completions`.
+    """
+    targets = kwargs.get("targets") or [None] * len(completions)
+    rewards = [
+        1.0 if target and target.strip() in completion else 0.0
+        for completion, target in zip(completions, targets)
+    ]
+    return torch.tensor(rewards, dtype=torch.float)
+```
+
+The returned tensor must have exactly `batch_size * group_size` entries. A mismatch raises
+a `ValueError` naming both counts.
+
+If `--reward-fn` is omitted, a placeholder reward equal to the character length of the
+completion is used. It exists to let the loop run and will train the model to produce
+longer output. Do not use it for real training.
+
+### Zero-variance groups
+
+Advantages are normalized within each group. When every completion for a prompt receives
+the same reward the group's standard deviation is zero, its advantages are zero, and it
+contributes no gradient. This is expected early in a run, and the trainer logs a warning
+with the number of affected groups. Persistent warnings mean the reward function is not
+discriminating between completions.
+
+## Example Configurations
+
+### Math (GSM8K), single 24 GB GPU
+
+```bash
+thinkrl grpo \
+    --model Qwen/Qwen2.5-0.5B-Instruct \
+    --ref-model Qwen/Qwen2.5-0.5B-Instruct \
+    --dataset openai/gsm8k --dataset-config main \
+    --prompt-column question --target-column answer \
+    --group-size 8 --batch-size 2 --max-length 512 \
+    --lora-r 16 --bf16 --gradient-checkpointing \
+    --reward-fn my_reward.py:reward_fn \
+    --logging-backend wandb
+```
+
+### Local JSONL
+
+Each line needs a prompt field and, if the reward function uses targets, an answer field:
+
+```json
+{"prompt": "What is 12 plus 30?", "answer": "42"}
+```
+
+```bash
+thinkrl grpo \
+    --model ./my-model --ref-model ./my-model \
+    --dataset ./data.jsonl --source json \
+    --group-size 8 --batch-size 2 \
+    --reward-fn my_reward.py:reward_fn
+```
+
+### Validating a configuration without training
+
+```bash
+thinkrl grpo ... --dry-run
+```
+
+Loads both models, the tokenizer, the dataset and the trainer, then exits. Use it to catch
+argument and memory problems before committing to a run.


### PR DESCRIPTION
Closes #66.

`README.md` states that GRPO CLI commands and standalone scripts are "fully Production-Ready", which does not match the current state of the training loop. This change describes GRPO as working with known limitations and lists them, so the README reflects what the code does.

The custom reward function example is also incorrect. The README documents `def math_reward(completion, answer)`, but the trainer calls `reward_fn(prompts, completions, targets=...)` and expects a tensor of shape `[B*G]`. A function written to the documented signature raises `TypeError` on the first step. This change replaces it with the real contract, which `docs/reinforce_pp.md` already documents correctly. `README.md:246` also refers to `python -m thinkrl.cli.merge_lora`, which does not exist; the command is `thinkrl merge` with `--base-model`, `--adapter` and `--output`.

This adds `docs/grpo.md`, following the structure of the existing `docs/reinforce_pp.md`, covering the CLI, the reward function contract, the relationship between group size and memory, and zero-variance groups. GRPO had no algorithm document before this.

Please note this branch is stacked on the branch for #64 and contains that commit as well, because the wording here describes the guards that PR adds. #64 should land first, after which this diff reduces to the README and `docs/grpo.md` only. The full test suite is unchanged from `main` at 738 passed.

@Archit03 the limitations list is written from reading the code, so please correct anything I have characterised wrongly.
