### PR TITLE
Move cupy out of core dependencies into the existing cuda extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ def read_version():
 # Core dependencies - minimal, stable, no GPU requirements
 CORE_REQUIREMENTS = [
     "torch>=2.0.0,<3.0.0",
-    "cupy-cuda12x>=12.0.0,<13.0.0",
     "scipy>=1.10.0",
     "pyyaml>=6.0,<7.0",
     "tqdm>=4.65.0",
@@ -61,7 +60,7 @@ CORE_REQUIREMENTS = [
 # GPU Acceleration
 GPU_REQUIREMENTS = {
     "cuda": [
-        "cupy-cuda12x>=12.0.0,<13.0.0",
+        "cupy-cuda12x>=12.0.0",
     ],
     # Assuming cuda11 might still be relevant for some users
     "cuda11": [


### PR DESCRIPTION
Closes #70.

`cupy-cuda12x` was listed in `CORE_REQUIREMENTS`, whose own comment reads "minimal, stable, no GPU requirements". There are no wheels for macOS or ARM, so `pip install thinkrl` could not resolve at all on those platforms. On Linux with CUDA 12 the `<13.0.0` cap forced cupy 12.x, which pins `numpy<1.27`, downgrading numpy from 2.x and breaking the ABI of every package compiled against numpy 2, including numpy itself.

CuPy is imported in one place, `thinkrl/utils/metrics.py:22`, already inside a `try`/`except` whose comment states it handles absence gracefully. A `cuda` extra containing the same dependency already existed, so this moves it there rather than adding anything new, and drops the upper bound so it can coexist with numpy 2 and the RAPIDS stack.

Verified that the remaining core set resolves on macOS arm64, where the previous set returned `No matching distribution found for cupy-cuda12x<13.0.0,>=12.0.0`. Two lines changed. `accelerate>=0.21.0,<1.0.0` on the same list also excludes the current 1.x series and may be worth revisiting separately.

@Archit03