### PR TITLE
Order filterwarnings so the ignore rules take effect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,14 @@ markers = [
 ]
 
 filterwarnings = [
+    # pytest gives later entries higher precedence, so "error" must come first
+    # for the ignore rules below it to take effect.
+    "error",
     "ignore:.*transformers not available.*:UserWarning",
     "ignore::UserWarning:torch.utils.checkpoint:",
     "ignore::FutureWarning:transformers.tokenization_utils_base:",
     "ignore::UserWarning:cupy.cuda.memory:",
     "ignore::DeprecationWarning",
-    "error",
 ]
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
Closes #71.

pytest gives later entries in `filterwarnings` higher precedence than earlier ones. `"error"` sat last in the list, so it overrode all five `ignore` rules above it and every one of them was dead. This is why the scheduled `Tests main with latest dependencies` workflow reported 4 failures and 16 errors, all in `tests/test_utils/test_tokenizer.py` and all reading `DeprecationWarning: BPE.__init__ will not create from files anymore`.

Moving `"error"` to the front, with a comment recording why the order matters, takes the suite from 4 failed / 738 passed / 16 errors to 1 failed / 757 passed / 0 errors. No source file is touched, only the pytest configuration.

The one remaining failure is a genuine transformers 5.x change that this noise was concealing, and is addressed in a follow-up PR stacked on this one.

@Archit03