### PR TITLE
Accept the transformers 5.x tokenizer save layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,14 @@ markers = [
 ]
 
 filterwarnings = [
+    # pytest gives later entries higher precedence, so "error" must come first
+    # for the ignore rules below it to take effect.
+    "error",
     "ignore:.*transformers not available.*:UserWarning",
     "ignore::UserWarning:torch.utils.checkpoint:",
     "ignore::FutureWarning:transformers.tokenization_utils_base:",
     "ignore::UserWarning:cupy.cuda.memory:",
     "ignore::DeprecationWarning",
-    "error",
 ]
 
 # ------------------------------------------------------------------

--- a/tests/test_utils/test_tokenizer.py
+++ b/tests/test_utils/test_tokenizer.py
@@ -3,6 +3,7 @@ Test Suite for ThinkRL Tokenizer Utilities
 ==========================================
 """
 
+import json
 from pathlib import Path
 import shutil
 import tempfile
@@ -237,7 +238,16 @@ class TestTokenizers:
         save_tokenizer(tokenizer_to_save, temp_dir)
 
         assert (temp_dir / "tokenizer.json").exists()
-        assert (temp_dir / "special_tokens_map.json").exists()
+        # transformers 5.x stopped writing special_tokens_map.json and moved the
+        # special tokens into tokenizer_config.json, renaming the key from
+        # additional_special_tokens to extra_special_tokens. Accept either layout.
+        assert (temp_dir / "tokenizer_config.json").exists()
+        config = json.loads((temp_dir / "tokenizer_config.json").read_text())
+        added = config.get("extra_special_tokens") or config.get("additional_special_tokens") or []
+        if (temp_dir / "special_tokens_map.json").exists():
+            mapping = json.loads((temp_dir / "special_tokens_map.json").read_text())
+            added = added or mapping.get("additional_special_tokens") or []
+        assert "<|my_token|>" in added
 
         loaded_tokenizer = load_tokenizer(temp_dir)
 


### PR DESCRIPTION
Closes #72.

transformers 5.x no longer writes `special_tokens_map.json`. Special tokens are stored in `tokenizer_config.json`, and the key was renamed from `additional_special_tokens` to `extra_special_tokens`. `test_save_and_load_tokenizer` asserted on the old file and failed against the latest dependencies.

This asserts on `tokenizer_config.json` and accepts either key name, so the test passes on both the 4.x and 5.x series and keeps serving the forward compatibility purpose the nightly workflow exists for. It also now asserts that the added token is actually present, which the original did not check.

Please note this is stacked on the filterwarnings ordering PR. Without that change this failure is hidden behind twenty warning-as-error results and the branch looks no different from `main`. With both applied the suite is 758 passed, 0 failed, 0 errors.

@Archit03