### PR TITLE
Raise NotImplementedError from PRMTrainer instead of returning empty results

### DIFF
--- a/thinkrl/models/prm.py
+++ b/thinkrl/models/prm.py
@@ -473,8 +473,8 @@ class PRMTrainer:
     - Class imbalance handling
     - Evaluation metrics (step accuracy, path accuracy)
 
-    TODO: Implement full trainer logic in future iteration.
-    For now, this is a placeholder.
+    Not yet implemented. Every method raises NotImplementedError rather than
+    returning an empty result, so callers cannot mistake it for a completed run.
     """
 
     def __init__(
@@ -494,12 +494,14 @@ class PRMTrainer:
 
     def train(self) -> dict[str, Any]:
         """Run training."""
-        logger.warning("PRMTrainer.train not fully implemented.")
-        return {}
+        raise NotImplementedError(
+            "PRMTrainer.train is not implemented. Returning an empty result would let a "
+            "caller treat an untrained model as trained."
+        )
 
     def evaluate(self) -> dict[str, float]:
         """Run evaluation."""
-        return {}
+        raise NotImplementedError("PRMTrainer.evaluate is not implemented.")
 
     def compute_metrics(
         self,
@@ -514,7 +516,7 @@ class PRMTrainer:
             - path_accuracy: Full path correct rate
             - first_error_position: Avg position of first error
         """
-        return {}
+        raise NotImplementedError("PRMTrainer.compute_metrics is not implemented.")
 
 
 def create_prm(


### PR DESCRIPTION
Closes #74.

`PRMTrainer.train` logged a warning and returned `{}`, while `evaluate` and `compute_metrics` returned `{}` with no message at all. A caller therefore saw training succeed and continued, and the process exited 0. `compute_metrics` documents three keys, `step_accuracy`, `path_accuracy` and `first_error_position`, and returned none of them.

This is the same failure mode as #64 in a different module, and unlike #64 it is unconditional rather than dependent on configuration.

These methods now raise `NotImplementedError`, which makes the state visible to callers without pretending to more capability than exists. The class docstring is updated to say so rather than describing itself as a placeholder while behaving like a working trainer.

The README currently presents PRM as production-ready with "Full support"; that is worth revisiting separately, and I have not touched it here.

@Archit03