### PR TITLE
Fall back to default attention when flash-attn is unavailable

### DIFF
--- a/thinkrl/models/actor.py
+++ b/thinkrl/models/actor.py
@@ -10,6 +10,8 @@ Author: Archit Sood @ EllanorAI
 
 from __future__ import annotations
 
+import importlib.util
+
 import logging
 
 import torch
@@ -34,6 +36,11 @@ try:
     _PEFT_AVAILABLE = True
 except ImportError:
     _PEFT_AVAILABLE = False
+
+
+def _flash_attention_available() -> bool:
+    """Return True when flash-attn is importable, matching the docstring's "if available"."""
+    return importlib.util.find_spec("flash_attn") is not None
 
 
 class Actor(nn.Module):
@@ -102,7 +109,13 @@ class Actor(nn.Module):
         if isinstance(pretrained_model, str):
             config_kwargs = {}
             if use_flash_attention:
-                config_kwargs["attn_implementation"] = "flash_attention_2"
+                if _flash_attention_available():
+                    config_kwargs["attn_implementation"] = "flash_attention_2"
+                else:
+                    logger.warning(
+                        "use_flash_attention=True but flash-attn is not installed. "
+                        "Falling back to the default attention implementation."
+                    )
 
             config = AutoConfig.from_pretrained(
                 pretrained_model,


### PR DESCRIPTION
Closes #81.

`Actor`'s docstring says "use_flash_attention: Use Flash Attention 2 if available" and the parameter defaults to `True`, but `attn_implementation` was set unconditionally with no availability probe. Constructing the class at its documented defaults therefore raised `ImportError` on any machine without flash-attn, which includes macOS, CPU-only hosts, and a default Kaggle or Colab image. `flash-attn` is not declared as a dependency anywhere, optional or otherwise.

This probes with `importlib.util.find_spec` and falls back to the default attention implementation with a warning, implementing the behaviour the docstring already describes. Verified that `Actor(pretrained_model=path)` previously raised and now succeeds with a warning.

Worth noting separately: the library default here is `True` while `cli/grpo.py:54` defaults `--flash-attn` to `False`, so the two currently disagree. This PR does not change either default, only the fallback.

@Archit03