### PR TITLE
Make RewardPipeline satisfy the trainer contract and reject bad score counts

### DIFF
--- a/thinkrl/rewards/pipeline.py
+++ b/thinkrl/rewards/pipeline.py
@@ -22,22 +22,39 @@ class RewardPipeline:
         """
         self.scorers = scorers
 
-    def __call__(self, prompts: list[str], completions: list[str]) -> torch.Tensor:
+    def __call__(self, prompts: list[str], completions: list[str], **kwargs) -> torch.Tensor:
         """
         Compute weighted sum of rewards.
+
+        Extra keyword arguments are accepted and forwarded to any scorer that
+        declares them, so this satisfies the trainer contract, which passes
+        ``targets=`` on every step.
         """
         if not self.scorers:
-            # Return zeros if no scorers
-            return torch.zeros(len(completions), dtype=torch.float)
+            raise ValueError(
+                "RewardPipeline was constructed with no scorers. Returning zeros would "
+                "give every completion an identical reward, which yields no gradient."
+            )
 
         total_rewards = None
 
         for scorer, weight in self.scorers:
-            scores = scorer(prompts, completions)
+            try:
+                scores = scorer(prompts, completions, **kwargs)
+            except TypeError:
+                # Scorer does not accept the extra keywords; call it plainly.
+                scores = scorer(prompts, completions)
 
             # Ensure tensor
             if not isinstance(scores, torch.Tensor):
                 scores = torch.tensor(scores, dtype=torch.float)
+
+            if scores.shape[0] != len(completions):
+                raise ValueError(
+                    f"{type(scorer).__name__} returned {scores.shape[0]} scores for "
+                    f"{len(completions)} completions. Broadcasting a mismatched count "
+                    f"would silently give completions the wrong reward."
+                )
 
             weighted_scores = scores * weight
 


### PR DESCRIPTION
Closes #78.

`GRPOTrainer` passes `targets=` on every step, because `RLHFDataset` always returns a `target` key, so it is never `None`. `RewardPipeline.__call__` accepted only `(prompts, completions)` and therefore raised `TypeError` immediately. The library's own reward composition class could not be used with the library's own GRPO trainer at all.

This accepts and forwards `**kwargs`, falling back to a plain two-argument call for scorers that do not declare them, so existing scorers keep working. It also raises when a scorer returns a score count that does not match the completion count, which previously broadcast silently and gave every completion in a group the same reward, producing zero variance and no gradient while the run reported normal metrics. An empty scorer list now raises for the same reason instead of returning zeros.

Verified that `targets=` is accepted, that a scorer returning 1 score for 4 completions now raises rather than broadcasting to `[10.0, 10.0, 10.0, 10.0]`, and that the suite is unchanged from `main`.

@Archit03