### PR TITLE
Raise instead of warning when a prompt column matches no rows

### DIFF
--- a/thinkrl/data/datasets.py
+++ b/thinkrl/data/datasets.py
@@ -143,9 +143,12 @@ class RLHFDataset(BaseRLHFDataset):
             self.data.append(item)
 
         if not self.data:
-            logger.warning(
-                f"No valid samples found in {dataset_name_or_path} with prompt_column='{prompt_column}'. "
-                f"Dataset length: {len(self.dataset)}"
+            available = list(self.dataset[0].keys()) if len(self.dataset) else []
+            raise ValueError(
+                f"No valid samples found in {dataset_name_or_path} with "
+                f"prompt_column='{prompt_column}'. The dataset has {len(self.dataset)} row(s) "
+                f"and its columns are {available}. Training would run zero steps and report "
+                f"success. Pass the correct --prompt-column."
             )
         else:
             logger.info(f"Loaded {len(self.data)} valid samples from {dataset_name_or_path}")


### PR DESCRIPTION
Closes #77 partially.

`RLHFDataset` logged a warning when filtering removed every row and returned an empty dataset. `cli/grpo.py:249` then computed `total_steps = epochs * 0 // batch_size = 0`, so training ran zero steps, printed "Training complete." and saved an untrained checkpoint. The realistic trigger is the CLI's own defaults: `--prompt-column` defaults to `"prompt"` while the `--dataset-config` help text suggests gsm8k, whose columns are `question` and `answer`.

This raises instead, naming the requested column, the row count, and the columns actually present, so the mistake is reported where it happens rather than as a silent success several steps later.

Please note this covers only the first half of the issue. The second half, prompts that survive the string check but tokenize to zero tokens and reach `generate()` as all-padding rows, is deliberately not addressed here. Probing the tokenizer per row inside `__init__` tokenizes the dataset twice and misreads test doubles; I tried it and it broke `tests/test_data/test_datasets.py`. The better home is a single `attention_mask.sum(dim=1) > 0` check in `GRPOTrainer.make_experience` before generation, which I am happy to send as a follow-up if you agree with that placement.

@Archit03