### PR TITLE
Load checkpoints with weights_only=True

### DIFF
--- a/tests/test_utils/test_checkpoint_load_security.py
+++ b/tests/test_utils/test_checkpoint_load_security.py
@@ -1,0 +1,96 @@
+"""Checkpoint loading must not unpickle arbitrary objects.
+
+Every torch.load call in the loading path used weights_only=False, so a crafted
+model.pt executed its pickle __reduce__ payload as soon as the checkpoint was
+loaded. These tests drive the real CheckpointManager API, not torch.load.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+from thinkrl.utils.checkpoint import CheckpointManager, load_checkpoint
+
+
+class _Payload:
+    """Innocuous-looking object whose unpickling runs a shell command."""
+
+    def __init__(self, marker: str):
+        self.marker = marker
+
+    def __reduce__(self):
+        return (os.system, (f"touch {self.marker}",))
+
+
+def _write_malicious_checkpoint(directory: Path, marker: Path) -> Path:
+    model_path = directory / "model.pt"
+    torch.save({"payload": _Payload(str(marker))}, model_path)
+    return model_path
+
+
+def test_manager_load_does_not_execute_pickle_payload(tmp_path):
+    marker = tmp_path / "PWNED"
+    ckpt_dir = tmp_path / "checkpoint-1"
+    ckpt_dir.mkdir()
+    _write_malicious_checkpoint(ckpt_dir, marker)
+
+    manager = CheckpointManager(checkpoint_dir=tmp_path / "checkpoints")
+    with pytest.raises(Exception):
+        manager.load_checkpoint(ckpt_dir, model=nn.Linear(2, 2))
+
+    assert not marker.exists(), "pickle payload executed during load_checkpoint"
+
+
+def test_module_level_load_does_not_execute_pickle_payload(tmp_path):
+    marker = tmp_path / "PWNED"
+    model_path = _write_malicious_checkpoint(tmp_path, marker)
+
+    with pytest.raises(Exception):
+        load_checkpoint(model_path, model=nn.Linear(2, 2))
+
+    assert not marker.exists(), "pickle payload executed during load_checkpoint()"
+
+
+def test_optimizer_state_load_does_not_execute_pickle_payload(tmp_path):
+    """The optimizer path is a separate torch.load call and needs its own pin."""
+    marker = tmp_path / "PWNED_OPTIM"
+    ckpt_dir = tmp_path / "checkpoint-1"
+    ckpt_dir.mkdir()
+
+    model = nn.Linear(2, 2)
+    torch.save(model.state_dict(), ckpt_dir / "model.pt")
+    torch.save({"payload": _Payload(str(marker))}, ckpt_dir / "optimizer.pt")
+
+    manager = CheckpointManager(checkpoint_dir=tmp_path / "checkpoints")
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    with pytest.raises(Exception):
+        manager.load_checkpoint(ckpt_dir, model=model, optimizer=optimizer)
+
+    assert not marker.exists(), "pickle payload executed while loading optimizer state"
+
+
+def test_no_load_site_reintroduces_weights_only_false():
+    for filename in (
+        "thinkrl/utils/checkpoint.py",
+        "thinkrl/models/reward_model.py",
+        "thinkrl/models/critic.py",
+    ):
+        assert "weights_only=False" not in Path(filename).read_text(), filename
+
+
+def test_round_trip_still_works(tmp_path):
+    """weights_only=True must not break ordinary checkpoints."""
+    model = nn.Linear(4, 3)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    manager = CheckpointManager(checkpoint_dir=tmp_path / "checkpoints")
+    path = manager.save_checkpoint(model=model, optimizer=optimizer, epoch=1, step=10)
+
+    restored = nn.Linear(4, 3)
+    restored_optimizer = torch.optim.SGD(restored.parameters(), lr=0.1)
+    manager.load_checkpoint(path, model=restored, optimizer=restored_optimizer)
+
+    for a, b in zip(model.parameters(), restored.parameters(), strict=True):
+        assert torch.equal(a, b)

--- a/thinkrl/models/critic.py
+++ b/thinkrl/models/critic.py
@@ -308,5 +308,5 @@ class Critic(nn.Module):
 
         value_head_path = os.path.join(model_path, "value_head.pt")
         if os.path.exists(value_head_path):
-            critic.value_head.load_state_dict(torch.load(value_head_path))
+            critic.value_head.load_state_dict(torch.load(value_head_path, weights_only=True))
         return critic

--- a/thinkrl/models/reward_model.py
+++ b/thinkrl/models/reward_model.py
@@ -333,7 +333,7 @@ class RewardModel(nn.Module):
 
         reward_head_path = os.path.join(model_path, "reward_head.pt")
         if os.path.exists(reward_head_path):
-            state = torch.load(reward_head_path)
+            state = torch.load(reward_head_path, weights_only=True)
             rm.reward_head.load_state_dict(state["reward_head"])
             if state.get("reward_mean") is not None:
                 rm.reward_mean = state["reward_mean"]

--- a/thinkrl/utils/checkpoint.py
+++ b/thinkrl/utils/checkpoint.py
@@ -274,10 +274,11 @@ class CheckpointManager:
             raise FileNotFoundError(f"Model checkpoint not found: {model_path}")
 
         # Load model state
+        # weights_only=True: never unpickle arbitrary objects from a checkpoint file (RCE).
         if model_path.suffix == ".safetensors":
             state_dict = safetensors_load(str(model_path), device=str(device) if device else "cpu")
         else:
-            state_dict = torch.load(model_path, map_location=device, weights_only=False)
+            state_dict = torch.load(model_path, map_location=device, weights_only=True)
 
         # Handle DataParallel/DistributedDataParallel wrapped models
         if isinstance(model, nn.DataParallel | nn.parallel.DistributedDataParallel):
@@ -290,14 +291,14 @@ class CheckpointManager:
         if optimizer is not None:
             optimizer_path = checkpoint_dir / "optimizer.pt"
             if optimizer_path.exists():
-                optimizer.load_state_dict(torch.load(optimizer_path, map_location=device, weights_only=False))
+                optimizer.load_state_dict(torch.load(optimizer_path, map_location=device, weights_only=True))
                 logger.debug(f"Loaded optimizer from: {optimizer_path}")
 
         # Load scheduler
         if scheduler is not None:
             scheduler_path = checkpoint_dir / "scheduler.pt"
             if scheduler_path.exists():
-                scheduler.load_state_dict(torch.load(scheduler_path, map_location=device, weights_only=False))
+                scheduler.load_state_dict(torch.load(scheduler_path, map_location=device, weights_only=True))
                 logger.debug(f"Loaded scheduler from: {scheduler_path}")
 
         # Load metadata
@@ -663,7 +664,7 @@ def load_checkpoint(
         else:
             checkpoint = {"model_state_dict": state_dict}
     else:
-        checkpoint = torch.load(checkpoint_path, map_location=device, weights_only=False)
+        checkpoint = torch.load(checkpoint_path, map_location=device, weights_only=True)
 
     # Load model state
     if isinstance(model, nn.DataParallel | nn.parallel.DistributedDataParallel):


### PR DESCRIPTION
Closes #121.

Every non-safetensors load path in `utils/checkpoint.py` passed `weights_only=False`, so loading a checkpoint unpickled whatever the file contained and ran its `__reduce__`. This pins `weights_only=True` on the model, optimizer, scheduler and module-level load calls, and on the two value/reward head loads in `models/critic.py` and `models/reward_model.py` that had no argument at all.

Optimizer and scheduler `state_dict`s are tensors and plain containers, so they restore unchanged under the safe unpickler. The added test file drives `CheckpointManager.load_checkpoint` with an `os.system` payload and asserts the marker file is never created, covers the optimizer path separately since it is its own `torch.load` call, and keeps an ordinary save/load round trip green. Reverting the fix turns 4 of the 5 tests red.