### PR TITLE
Render RL prompts with the tokenizer chat template

### DIFF
--- a/tests/test_data/test_chat_template.py
+++ b/tests/test_data/test_chat_template.py
@@ -1,0 +1,107 @@
+"""RL prompts must go through the tokenizer's chat template.
+
+Nothing in thinkrl/cli or thinkrl/training called apply_chat_template, so an
+instruct checkpoint was rolled out on bare prompt strings: generation still
+worked, rewards were still computed, and the policy was optimized off the
+distribution it was aligned to.
+"""
+
+import pytest
+import torch
+
+from thinkrl.data.datasets import RLHFDataset
+
+
+SAMPLES = [{"prompt": "What is 2+2?", "answer": "4", "response": "It is 4."}]
+
+
+class ChatTokenizer:
+    """Mock tokenizer that renders a recognisable chat template."""
+
+    chat_template = "{% for m in messages %}<|{{ m.role }}|>{{ m.content }}{% endfor %}"
+
+    def __init__(self):
+        self.pad_token_id = 0
+        self.eos_token = "<EOS>"
+        self.eos_token_id = 1
+        self.last_add_special_tokens = None
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False, **kwargs):
+        rendered = "".join(f"<|{m['role']}|>{m['content']}" for m in messages)
+        if add_generation_prompt:
+            rendered += "<|assistant|>"
+        return rendered
+
+    def __call__(self, text, max_length=None, padding=False, truncation=False, return_tensors=None, **kwargs):
+        self.last_add_special_tokens = kwargs.get("add_special_tokens")
+        ids = [len(tok) for tok in text.split()] or [1]
+        if truncation and max_length:
+            ids = ids[:max_length]
+        tensor = torch.tensor([ids], dtype=torch.long)
+        return {"input_ids": tensor, "attention_mask": torch.ones_like(tensor)}
+
+
+class PlainTokenizer(ChatTokenizer):
+    """Base model: no template defined."""
+
+    chat_template = None
+
+
+class BrokenTemplateTokenizer(ChatTokenizer):
+    def apply_chat_template(self, *args, **kwargs):
+        raise ValueError("template does not support the system role")
+
+
+def _dataset(tokenizer, **kwargs):
+    return RLHFDataset(dataset_name_or_path=SAMPLES, tokenizer=tokenizer, **kwargs)
+
+
+def test_prompt_is_rendered_with_generation_prompt():
+    sample = _dataset(ChatTokenizer())[0]
+    assert sample["prompt_text"] == "<|user|>What is 2+2?<|assistant|>"
+
+
+def test_system_prompt_becomes_a_system_message():
+    sample = _dataset(ChatTokenizer(), system_prompt="Think step by step.")[0]
+    assert sample["prompt_text"] == "<|system|>Think step by step.<|user|>What is 2+2?<|assistant|>"
+    assert "Think step by step.\n\nWhat is 2+2?" not in sample["prompt_text"]
+
+
+def test_rendered_text_is_tokenized_without_extra_special_tokens():
+    """A rendered template already carries BOS and role markers."""
+    tokenizer = ChatTokenizer()
+    _dataset(tokenizer)[0]
+    assert tokenizer.last_add_special_tokens is False
+
+
+def test_base_model_tokenizer_is_untouched():
+    tokenizer = PlainTokenizer()
+    sample = _dataset(tokenizer)[0]
+    assert sample["prompt_text"] == "What is 2+2?"
+    assert tokenizer.last_add_special_tokens is True
+
+
+def test_flag_disables_templating():
+    sample = _dataset(ChatTokenizer(), apply_chat_template=False)[0]
+    assert sample["prompt_text"] == "What is 2+2?"
+
+
+def test_sft_mode_puts_the_response_in_an_assistant_turn():
+    dataset = _dataset(ChatTokenizer(), response_column="response")
+    sample = dataset[0]
+    _, text, templated = dataset._render("What is 2+2?", "It is 4.")
+    assert templated
+    assert text == "<|user|>What is 2+2?<|assistant|>It is 4."
+    assert sample["prompt_text"] == "<|user|>What is 2+2?<|assistant|>"
+
+
+def test_failing_template_falls_back_instead_of_crashing(caplog):
+    dataset = _dataset(BrokenTemplateTokenizer(), system_prompt="sys")
+    sample = dataset[0]
+    assert sample["prompt_text"] == "sys\n\nWhat is 2+2?"
+    assert dataset._chat_template_failed is True
+
+
+def test_target_column_survives_templating():
+    sample = _dataset(ChatTokenizer())[0]
+    assert sample["target"] == "4"

--- a/thinkrl/cli/grpo.py
+++ b/thinkrl/cli/grpo.py
@@ -80,6 +80,14 @@ def grpo(
     system_prompt: Annotated[
         str | None, Option("--system-prompt", help="System prompt to prepend to each input")
     ] = "You are a helpful arithmetic reasoning assistant. Your task is to solve the given math problem. You must think step-by-step and write out your complete train of thought inside <think></think> tags. After you have finished thinking, you must provide your final numerical answer enclosed exactly inside <answer></answer> tags.",
+    chat_template: Annotated[
+        bool,
+        Option(
+            "--chat-template/--no-chat-template",
+            help="Render prompts with the tokenizer's chat template (instruct models). "
+            "Disable for base models or datasets that are already formatted.",
+        ),
+    ] = True,
     dry_run: Annotated[bool, Option("--dry-run", help="Initialize and validate, but do not train")] = False,
 ):
     """
@@ -180,6 +188,7 @@ def grpo(
         target_column=target_column,
         dataset_config=dataset_config,
         system_prompt=system_prompt,
+        apply_chat_template=chat_template,
     )
 
     if reward_fn:

--- a/thinkrl/cli/star.py
+++ b/thinkrl/cli/star.py
@@ -54,6 +54,14 @@ def star(
         str | None, Option("--reward-fn", help="Path to reward function (module.py:func_name)")
     ] = None,
     target_column: Annotated[str, Option("--target-column", help="Column name for target answers")] = "answer",
+    chat_template: Annotated[
+        bool,
+        Option(
+            "--chat-template/--no-chat-template",
+            help="Render prompts with the tokenizer's chat template (instruct models). "
+            "Disable for base models or datasets that are already formatted.",
+        ),
+    ] = True,
     dry_run: Annotated[bool, Option("--dry-run", help="Initialize and validate, but do not train")] = False,
 ):
     """
@@ -113,6 +121,7 @@ def star(
         source=source,
         target_column=target_column,
         dataset_config=dataset_config,
+        apply_chat_template=chat_template,
     )
 
     if reward_fn:

--- a/thinkrl/data/datasets.py
+++ b/thinkrl/data/datasets.py
@@ -102,6 +102,7 @@ class RLHFDataset(BaseRLHFDataset):
         max_samples: int | None = None,
         split: str = "train",
         preprocess_fn: Callable | None = None,
+        apply_chat_template: bool = True,
         **kwargs,
     ):
         super().__init__(
@@ -116,6 +117,8 @@ class RLHFDataset(BaseRLHFDataset):
         self.response_column = response_column
         self.system_prompt = kwargs.get("system_prompt", None)
         self.target_column = kwargs.get("target_column", "answer")
+        self.apply_chat_template = apply_chat_template
+        self._chat_template_failed = False
 
         # Filter and load data into memory to handle invalid rows efficiently
         self.data = []
@@ -150,27 +153,76 @@ class RLHFDataset(BaseRLHFDataset):
         else:
             logger.info(f"Loaded {len(self.data)} valid samples from {dataset_name_or_path}")
 
+    def _use_chat_template(self) -> bool:
+        """Chat template applies only when asked for and the tokenizer defines one."""
+        if not self.apply_chat_template or self._chat_template_failed:
+            return False
+        if not hasattr(self.tokenizer, "apply_chat_template"):
+            return False
+        return getattr(self.tokenizer, "chat_template", None) is not None
+
+    def _render(self, prompt: str, response: str | None) -> tuple[str, str, bool]:
+        """Return (prompt_text, text, templated).
+
+        prompt_text is what the policy is asked to continue, so it carries the
+        generation prompt. text is what gets tokenized, and in SFT mode also
+        carries the response. templated says whether the chat template ran, which
+        the caller needs because a rendered template already contains the special
+        tokens the tokenizer would otherwise add a second time.
+
+        Falls back to plain concatenation for base models, for tokenizers without
+        a template, and if rendering raises.
+        """
+        if self._use_chat_template():
+            messages = []
+            if self.system_prompt:
+                messages.append({"role": "system", "content": self.system_prompt})
+            messages.append({"role": "user", "content": prompt})
+            try:
+                prompt_text = self.tokenizer.apply_chat_template(
+                    messages, tokenize=False, add_generation_prompt=True
+                )
+                if response is None:
+                    return prompt_text, prompt_text, True
+                text = self.tokenizer.apply_chat_template(
+                    [*messages, {"role": "assistant", "content": response}],
+                    tokenize=False,
+                    add_generation_prompt=False,
+                )
+                return prompt_text, text, True
+            except Exception as exc:  # noqa: BLE001 - any jinja template can raise anything
+                self._chat_template_failed = True
+                logger.warning(
+                    f"Chat template failed ({exc}); falling back to raw prompts for this dataset. "
+                    "Pass apply_chat_template=False to silence this."
+                )
+
+        prompt_text = prompt
+        if self.system_prompt:
+            prompt_text = f"{self.system_prompt}\n\n{prompt}"
+        text = prompt_text if response is None else f"{prompt_text} {response}"
+        return prompt_text, text, False
+
     def __getitem__(self, idx: int) -> dict[str, Any]:
         sample = self.data[idx]
 
         prompt = sample.get(self.prompt_column)
 
-        if self.system_prompt:
-            prompt = f"{self.system_prompt}\n\n{prompt}"
-
-        # Add response if available (SFT mode)
-        text = prompt
+        response = None
         if self.response_column and self.response_column in sample:
             response = str(sample[self.response_column]).strip()
-            text = f"{prompt} {response}"
 
-        # Tokenize
+        prompt, text, templated = self._render(prompt, response)
+
+        # Tokenize. A rendered chat template already carries BOS and the role
+        # markers, so letting the tokenizer add specials again duplicates them.
         encodings = self.tokenizer(
             text,
             max_length=self.max_length,
             padding=False,  # Padding handled by collator
             truncation=True,
             return_tensors="pt",
+            add_special_tokens=not templated,
         )
 
         return {


### PR DESCRIPTION
Closes #123.

`RLHFDataset.__getitem__` tokenized the raw prompt column, and nothing in `thinkrl/cli` or `thinkrl/training` called `apply_chat_template`, so every instruct checkpoint in the README examples was rolled out on bare strings. That failure is quiet: generation works, rewards are computed, the loss moves, and the policy is being optimized off the distribution it was aligned to. `DataConfig.apply_chat_template` already defaulted to `True` while no code read it, which made it worse.

All three RL trainers and both working CLIs build their prompts from `RLHFDataset`, so the fix goes there:

- prompts render through `tokenizer.apply_chat_template` with `add_generation_prompt=True` when the tokenizer defines a template
- `system_prompt` becomes a system message rather than a `\n\n` prefix
- `prompt_text` carries the rendered string, so the vLLM path in `make_experience` sends the same text the local path tokenizes
- SFT mode puts the response in an assistant turn
- the tokenizer is called with `add_special_tokens=False` for rendered text, since the template already includes BOS and the role markers

Base models, tokenizers with no template, and `--no-chat-template` keep the old behaviour exactly, so the existing dataset tests are untouched (67 passed across `tests/test_data` and `tests/test_cli`). A template that rejects the role layout logs one warning and falls back instead of failing the run.

Eight tests cover rendering, the system turn, the double-special-token case, the base-model path, the flag, SFT mode and the fallback.