### PR TITLE
Compare maths answers as maths, not as trailing numbers

### DIFF
--- a/tests/test_rewards/test_math_verifier.py
+++ b/tests/test_rewards/test_math_verifier.py
@@ -1,0 +1,70 @@
+"""Maths answers must be compared as maths, not as trailing numbers.
+
+_check_math_correctness compared only the last number found in each string,
+so 1/3 never matched 0.333, \\boxed{42} never matched 42, and any answer that
+was not a bare number fell through to string equality.
+"""
+
+import pytest
+
+from thinkrl.rewards.universal import UniversalReward
+
+
+@pytest.fixture
+def reward():
+    return UniversalReward(math_tolerance=1e-4)
+
+
+@pytest.mark.parametrize(
+    ("pred", "target"),
+    [
+        ("4", "4"),
+        ("4.0", "4"),
+        ("1,000", "1000"),
+        (r"\boxed{42}", "42"),
+        (r"The answer is \boxed{42}.", "42"),
+        (r"\frac{1}{2}", "0.5"),
+        (r"\dfrac{3}{4}", "0.75"),
+        ("1/3", "0.3333333"),
+        ("#### 18", "18"),
+        ("$25$", "25"),
+        ("50%", "50"),
+        ("x^{2}", "x^2"),
+        ("(x+1)^2", "x^2+2*x+1"),
+        ("x+1", "1+x"),
+        ("The answer is 4", "4"),
+    ],
+)
+def test_equivalent_answers_are_accepted(reward, pred, target):
+    assert reward._check_math_correctness(pred, target) is True
+
+
+@pytest.mark.parametrize(
+    ("pred", "target"),
+    [
+        ("5", "6"),
+        ("1/3", "0.5"),
+        (r"\boxed{41}", "42"),
+        ("x+2", "1+x"),
+    ],
+)
+def test_wrong_answers_are_rejected(reward, pred, target):
+    assert reward._check_math_correctness(pred, target) is False
+
+
+def test_sympy_only_sees_expressions_made_of_maths_characters(reward):
+    """sympy parsing has eval semantics and completions are model output."""
+    payload = "__import__('os').system('touch /tmp/thinkrl_sympy_pwned')"
+    assert reward._SAFE_EXPR.match(payload) is None
+    assert reward._sympy_equal(payload, "1") is False
+
+
+def test_unparseable_input_is_not_a_match(reward):
+    assert reward._sympy_equal("((((", "1") is False
+
+
+def test_end_to_end_scores_a_latex_answer(reward):
+    """The whole reward, not just the helper."""
+    completions = [r"<think>half of one</think><answer>\frac{1}{2}</answer>"]
+    rewards = reward(["What is 1/2?"], completions, targets=["0.5"])
+    assert rewards[0].item() == pytest.approx(0.2 + 1.0)

--- a/thinkrl/rewards/universal.py
+++ b/thinkrl/rewards/universal.py
@@ -69,15 +69,85 @@ class UniversalReward(BaseScorer):
             return self._is_number(nums[-1])
         return None
 
+    # Only expressions made purely of these characters are handed to sympy.
+    # sympify parses with eval semantics, and completions are model output.
+    _SAFE_EXPR = re.compile(r"^[0-9a-zA-Z+\-*/^(). ]{1,100}$")
+
+    def _normalize_math(self, s: str) -> str:
+        """Strip the LaTeX and formatting that carries no mathematical content."""
+        s = s.strip()
+
+        # GSM8K style: the answer is what follows the marker.
+        if "####" in s:
+            s = s.split("####")[-1]
+
+        # \boxed{42} / \text{42} -> 42, innermost first so nesting unwraps.
+        for _ in range(3):
+            new_s = re.sub(r"\\(?:boxed|text|mathrm|mbox)\{([^{}]*)\}", r"\1", s)
+            if new_s == s:
+                break
+            s = new_s
+
+        # \frac{a}{b} and \dfrac{a}{b} -> (a)/(b)
+        for _ in range(3):
+            new_s = re.sub(r"\\[dt]?frac\{([^{}]*)\}\{([^{}]*)\}", r"(\1)/(\2)", s)
+            if new_s == s:
+                break
+            s = new_s
+
+        s = s.replace("\\left", "").replace("\\right", "")
+        s = s.replace("\\!", "").replace("\\,", "").replace("\\;", "").replace("\\ ", " ")
+        s = s.replace("$", "").replace("\\%", "").replace("%", "")
+        s = re.sub(r"\^\{([^{}]*)\}", r"^(\1)", s)  # x^{2} -> x^(2)
+        s = s.rstrip(".")
+        s = s.replace(",", "")  # 1,000 -> 1000
+        return re.sub(r"\s+", "", s)
+
+    def _sympy_equal(self, pred: str, target: str) -> bool:
+        """Symbolic equivalence, e.g. 1/3 against 0.333... or (x+1)^2 against x^2+2x+1."""
+        if not (self._SAFE_EXPR.match(pred) and self._SAFE_EXPR.match(target)):
+            return False
+        try:
+            from sympy import N, simplify
+            from sympy.parsing.sympy_parser import parse_expr
+
+            difference = simplify(parse_expr(pred.replace("^", "**")) - parse_expr(target.replace("^", "**")))
+            if difference == 0:
+                return True
+            value = N(difference)
+            return bool(value.is_number) and abs(float(value)) <= self.math_tolerance
+        except Exception:  # noqa: BLE001 - unparseable input is simply not a match
+            return False
+
     def _check_math_correctness(self, pred: str, target: str) -> bool:
-        """Check mathematical equivalence."""
-        pred_val = self._extract_last_number(pred)
-        target_val = self._extract_last_number(target)
-        
+        """Check mathematical equivalence.
+
+        Exact match on normalized forms first, then numeric comparison, then
+        symbolic equivalence. Comparing only the last number in each string is
+        kept as the final fallback because it is the one that rescues answers
+        written as prose ("the answer is 4"), but it is also the one that grades
+        "12 apples cost 4 dollars" as 4, so it must not run first.
+        """
+        norm_pred = self._normalize_math(pred)
+        norm_target = self._normalize_math(target)
+
+        if norm_pred and norm_pred == norm_target:
+            return True
+
+        pred_val = self._is_number(norm_pred)
+        target_val = self._is_number(norm_target)
         if pred_val is not None and target_val is not None:
             return math.isclose(pred_val, target_val, abs_tol=self.math_tolerance)
-            
-        # Fallback to exact string match for non-numeric math answers (e.g. "x + y")
+
+        if self._sympy_equal(norm_pred, norm_target):
+            return True
+
+        pred_val = self._extract_last_number(pred)
+        target_val = self._extract_last_number(target)
+        if pred_val is not None and target_val is not None:
+            return math.isclose(pred_val, target_val, abs_tol=self.math_tolerance)
+
+        # Non-numeric math answers (e.g. "x + y")
         return self._check_text_correctness(pred, target)
 
     def _check_code_correctness(self, pred: str, target: str) -> bool:


### PR DESCRIPTION
Part of #126, the maths half. The code-reward half is not touched here; containment is not salvageable by normalization and needs the separate execution decision described in the issue.

`_check_math_correctness` compared `_extract_last_number(pred)` against `_extract_last_number(target)`. That grades `1/3` against `0.3333` as wrong, `\\boxed{42}` against `42` as wrong, and sends every non-numeric answer to `_check_text_correctness`, which is string equality. On a maths RL run those are false negatives on correct completions, so the policy is punished for formatting.

New order: normalize, exact match, numeric comparison, sympy equivalence, and only then the old last-number comparison. Keeping that last step matters because it is what accepts "the answer is 4", but it is also what grades "12 apples cost 4 dollars" as 4, so it runs last rather than first.

Normalization covers `\\boxed`, `\\text`, `\\frac`/`\\dfrac`, `\\left`/`\\right`, spacing macros, `$`, `%`, thousands separators, `x^{2}`, and the GSM8K `####` marker.

sympy is already a core dependency (`requirements.txt:86`). It parses with eval semantics and the strings here are model output, so only expressions matching `^[0-9a-zA-Z+\\-*/^(). ]{1,100}$` reach the parser, which excludes quotes, brackets and underscores. There is a test asserting an `__import__` payload is refused and leaves no marker file.

22 new tests, existing 12 reward tests unchanged. Reverting the new ordering turns 6 of them red.