### PR TITLE
Add a reward model trainer

### DIFF
--- a/tests/test_training/test_rm_trainer.py
+++ b/tests/test_training/test_rm_trainer.py
@@ -1,0 +1,154 @@
+"""Reward model training.
+
+Step 2 of the RLHF pipeline had no implementation: models/reward_model.py was
+architecture only and PRMTrainer is a stub, so the reward checkpoint every RL
+example needs could not be produced by this library.
+"""
+
+import pytest
+import torch
+from torch import nn
+from torch.utils.data import Dataset
+
+from thinkrl.training.rm_trainer import RMConfig, RMTrainer, create_rm_trainer
+
+
+class TinyRewardModel(nn.Module):
+    """Scores a sequence with one number, like RewardModel does."""
+
+    def __init__(self, vocab_size=50, hidden=8):
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, hidden)
+        self.head = nn.Linear(hidden, 1)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        hidden = self.embedding(input_ids)
+        if attention_mask is not None:
+            mask = attention_mask.unsqueeze(-1).float()
+            pooled = (hidden * mask).sum(1) / mask.sum(1).clamp(min=1)
+        else:
+            pooled = hidden.mean(1)
+        return self.head(pooled).squeeze(-1)
+
+
+class StubTokenizer:
+    pad_token_id = 0
+    eos_token_id = 1
+
+
+class PairDataset(Dataset):
+    """Chosen sequences are longer than rejected, so padding is exercised."""
+
+    def __init__(self, n=8):
+        self.samples = [
+            {
+                "chosen_input_ids": torch.tensor([2, 3, 4, 5, 6], dtype=torch.long),
+                "chosen_attention_mask": torch.ones(5, dtype=torch.long),
+                "rejected_input_ids": torch.tensor([7, 8, 9], dtype=torch.long),
+                "rejected_attention_mask": torch.ones(3, dtype=torch.long),
+            }
+            for _ in range(n)
+        ]
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, idx):
+        return self.samples[idx]
+
+
+def _trainer(**kwargs):
+    kwargs.setdefault("per_device_train_batch_size", 4)
+    kwargs.setdefault("num_train_epochs", 1)
+    kwargs.setdefault("logging_steps", 1)
+    args = RMConfig(**kwargs)
+    return RMTrainer(
+        model=TinyRewardModel(),
+        tokenizer=StubTokenizer(),
+        train_dataset=PairDataset(),
+        args=args,
+    )
+
+
+def test_collator_pads_both_halves_to_one_length():
+    trainer = _trainer()
+    batch = trainer._default_collator([PairDataset()[0], PairDataset()[1]])
+    assert batch["input_ids"].shape == (4, 5)
+    assert batch["attention_mask"].shape == (4, 5)
+    # rejected sequences are 3 long, so their tail is masked
+    assert batch["attention_mask"][2].tolist() == [1, 1, 1, 0, 0]
+    assert batch["input_ids"][2].tolist()[3:] == [0, 0]
+
+
+def test_chosen_and_rejected_stay_in_their_halves():
+    trainer = _trainer()
+    batch = trainer._default_collator([PairDataset()[0], PairDataset()[1]])
+    first_half = batch["input_ids"][:2]
+    second_half = batch["input_ids"][2:]
+    assert (first_half[:, 0] == 2).all(), "chosen sequences are not the first half"
+    assert (second_half[:, 0] == 7).all(), "rejected sequences are not the second half"
+
+
+def test_loss_and_metrics_are_produced():
+    trainer = _trainer()
+    batch = next(iter(trainer.get_train_dataloader()))
+    loss, metrics = trainer.compute_loss(batch)
+    assert loss.dim() == 0
+    assert torch.isfinite(loss)
+    assert loss.requires_grad
+    assert set(metrics) >= {"rm_loss", "rm_accuracy", "reward_diff"}
+    assert 0.0 <= float(metrics["rm_accuracy"]) <= 1.0
+
+
+def test_training_makes_the_model_score_chosen_above_rejected():
+    """Asserts on the model itself, not on the metric the trainer reports.
+
+    Checking reward_diff alone passes even if chosen and rejected are swapped
+    inside compute_loss, because that metric is computed from the same swapped
+    variables. Scoring the two sequences directly is what pins the direction.
+    """
+    torch.manual_seed(0)
+    trainer = _trainer(learning_rate=0.1, num_train_epochs=30)
+    sample = PairDataset()[0]
+    chosen = sample["chosen_input_ids"].unsqueeze(0)
+    rejected = sample["rejected_input_ids"].unsqueeze(0)
+
+    trainer.train()
+
+    trainer.model.eval()
+    with torch.no_grad():
+        chosen_score = trainer.model(chosen, torch.ones_like(chosen))
+        rejected_score = trainer.model(rejected, torch.ones_like(rejected))
+
+    assert float(chosen_score) > float(rejected_score), "training did not rank chosen above rejected"
+    assert trainer.global_step > 0
+
+
+def test_missing_preference_columns_is_a_clear_error():
+    trainer = _trainer()
+    with pytest.raises(KeyError, match="chosen_input_ids"):
+        trainer._default_collator([{"input_ids": torch.tensor([1, 2])}])
+
+
+def test_tokenizer_is_required():
+    with pytest.raises(ValueError, match="tokenizer"):
+        RMTrainer(model=TinyRewardModel(), tokenizer=None, train_dataset=PairDataset())
+
+
+def test_save_model_writes_a_checkpoint(tmp_path):
+    trainer = _trainer()
+    out = trainer.save_model(str(tmp_path / "rm"))
+    assert (tmp_path / "rm" / "model.pt").exists()
+    assert out.endswith("rm")
+
+
+def test_factory_splits_config_arguments():
+    trainer = create_rm_trainer(
+        model=TinyRewardModel(),
+        tokenizer=StubTokenizer(),
+        train_dataset=PairDataset(),
+        learning_rate=3e-5,
+        margin=0.5,
+    )
+    assert trainer.args.learning_rate == 3e-5
+    assert trainer.loss_fn.margin == 0.5

--- a/thinkrl/training/__init__.py
+++ b/thinkrl/training/__init__.py
@@ -50,6 +50,11 @@ from .rl_utils import (
     # Group sampling
     sample_groups,
 )
+from .rm_trainer import (
+    RMConfig,
+    RMTrainer,
+    create_rm_trainer,
+)
 from .sft_trainer import (
     SFTConfig,
     SFTTrainer,
@@ -58,6 +63,10 @@ from .sft_trainer import (
 
 
 __all__ = [
+    # Reward Model Trainer
+    "RMConfig",
+    "RMTrainer",
+    "create_rm_trainer",
     # SFT Trainer
     "SFTConfig",
     "SFTTrainer",

--- a/thinkrl/training/rm_trainer.py
+++ b/thinkrl/training/rm_trainer.py
@@ -1,0 +1,241 @@
+"""
+Reward Model Trainer
+====================
+
+Pairwise preference training for reward models, the step between SFT and RL
+in the standard RLHF pipeline.
+
+Author: EllanorAI
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import os
+from typing import Any
+
+import torch
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+from thinkrl.models.loss import PairWiseLoss
+from thinkrl.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class RMConfig:
+    """Configuration for reward model training."""
+
+    # Optimization
+    learning_rate: float = 1e-5
+    weight_decay: float = 0.0
+    max_grad_norm: float = 1.0
+    warmup_ratio: float = 0.0
+
+    # Training
+    num_train_epochs: int = 1
+    per_device_train_batch_size: int = 4
+    gradient_accumulation_steps: int = 1
+
+    # Loss
+    margin: float = 0.0
+
+    # Logging and output
+    logging_steps: int = 10
+    output_dir: str = "./rm_output"
+
+
+class RMTrainer:
+    """
+    Trains a reward model on (chosen, rejected) preference pairs.
+
+    The objective is the standard Bradley-Terry pairwise loss,
+    ``-logsigmoid(r_chosen - r_rejected)``, implemented in
+    :class:`thinkrl.models.loss.PairWiseLoss`.
+
+    Example:
+        ```python
+        from thinkrl.data.datasets import PreferenceDataset
+        from thinkrl.models.reward_model import RewardModel
+
+        dataset = PreferenceDataset("Anthropic/hh-rlhf", tokenizer=tokenizer)
+        trainer = RMTrainer(
+            model=RewardModel("meta-llama/Llama-3.1-8B"),
+            tokenizer=tokenizer,
+            train_dataset=dataset,
+        )
+        trainer.train()
+        trainer.save_model("./rm_checkpoint")
+        ```
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        tokenizer: Any,
+        train_dataset: Any,
+        args: RMConfig | None = None,
+        data_collator: Callable | None = None,
+        device: torch.device | str | None = None,
+    ):
+        if model is None:
+            raise ValueError("RMTrainer requires a reward model.")
+        if tokenizer is None:
+            raise ValueError("RMTrainer requires a tokenizer: pairs are padded with its pad token.")
+
+        self.model = model
+        self.tokenizer = tokenizer
+        self.train_dataset = train_dataset
+        self.args = args or RMConfig()
+        self.data_collator = data_collator or self._default_collator
+        self.loss_fn = PairWiseLoss(margin=self.args.margin)
+
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device(device)
+
+        pad_token_id = getattr(tokenizer, "pad_token_id", None)
+        if pad_token_id is None:
+            pad_token_id = getattr(tokenizer, "eos_token_id", None)
+        if pad_token_id is None:
+            raise ValueError("Tokenizer has neither pad_token_id nor eos_token_id, so pairs cannot be padded.")
+        self.pad_token_id = pad_token_id
+
+        self.global_step = 0
+
+    def _default_collator(self, batch: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
+        """Pad chosen and rejected to one common length.
+
+        Both halves are padded together rather than separately, because they go
+        through the model as a single batch and a ragged split would misalign
+        the two reward vectors.
+        """
+        required = ("chosen_input_ids", "rejected_input_ids")
+        for key in required:
+            if key not in batch[0]:
+                raise KeyError(f"Preference batch is missing {key!r}; RMTrainer expects a PreferenceDataset.")
+
+        sequences = [torch.as_tensor(x["chosen_input_ids"]) for x in batch]
+        sequences += [torch.as_tensor(x["rejected_input_ids"]) for x in batch]
+        masks = [torch.as_tensor(x["chosen_attention_mask"]) for x in batch]
+        masks += [torch.as_tensor(x["rejected_attention_mask"]) for x in batch]
+
+        max_length = max(seq.size(0) for seq in sequences)
+        input_ids = torch.full((len(sequences), max_length), self.pad_token_id, dtype=torch.long)
+        attention_mask = torch.zeros((len(sequences), max_length), dtype=torch.long)
+        for i, (seq, mask) in enumerate(zip(sequences, masks, strict=True)):
+            input_ids[i, : seq.size(0)] = seq
+            attention_mask[i, : mask.size(0)] = mask
+
+        return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+    def get_train_dataloader(self) -> DataLoader:
+        if self.train_dataset is None:
+            raise ValueError("No training dataset provided.")
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.args.per_device_train_batch_size,
+            shuffle=True,
+            collate_fn=self.data_collator,
+            num_workers=0,
+            pin_memory=torch.cuda.is_available(),
+        )
+
+    def compute_loss(self, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Score both halves in one forward pass and rank them."""
+        input_ids = batch["input_ids"].to(self.device)
+        attention_mask = batch["attention_mask"].to(self.device)
+
+        rewards = self.model(input_ids=input_ids, attention_mask=attention_mask)
+        if isinstance(rewards, tuple):
+            rewards = rewards[0]
+        rewards = rewards.squeeze(-1) if rewards.dim() > 1 else rewards
+
+        # The collator stacks every chosen sequence before every rejected one.
+        half = rewards.size(0) // 2
+        chosen_rewards, rejected_rewards = rewards[:half], rewards[half:]
+        return self.loss_fn(chosen_rewards, rejected_rewards)
+
+    def train(self) -> dict[str, float]:
+        """Run pairwise training and return the last metrics."""
+        dataloader = self.get_train_dataloader()
+        if len(dataloader) == 0:
+            raise ValueError("Training dataloader is empty: no preference pairs to train on.")
+
+        self.model.to(self.device)
+        self.model.train()
+
+        optimizer = torch.optim.AdamW(
+            self.model.parameters(),
+            lr=self.args.learning_rate,
+            weight_decay=self.args.weight_decay,
+        )
+
+        total_steps = (len(dataloader) // self.args.gradient_accumulation_steps) * self.args.num_train_epochs
+        scheduler = None
+        if self.args.warmup_ratio > 0 and total_steps > 0:
+            warmup_steps = int(total_steps * self.args.warmup_ratio)
+            scheduler = torch.optim.lr_scheduler.LinearLR(
+                optimizer, start_factor=0.1, total_iters=max(warmup_steps, 1)
+            )
+
+        metrics: dict[str, float] = {}
+        for epoch in range(self.args.num_train_epochs):
+            progress = tqdm(dataloader, desc=f"RM epoch {epoch + 1}/{self.args.num_train_epochs}")
+            for step, batch in enumerate(progress):
+                loss, step_metrics = self.compute_loss(batch)
+                (loss / self.args.gradient_accumulation_steps).backward()
+
+                if (step + 1) % self.args.gradient_accumulation_steps == 0:
+                    torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.args.max_grad_norm)
+                    optimizer.step()
+                    if scheduler is not None:
+                        scheduler.step()
+                    optimizer.zero_grad()
+                    self.global_step += 1
+
+                metrics = {k: float(v) for k, v in step_metrics.items()}
+                if self.global_step and self.global_step % self.args.logging_steps == 0:
+                    logger.info(f"step {self.global_step}: {metrics}")
+
+        if self.global_step == 0:
+            raise RuntimeError(
+                "Reward model training finished without a single optimizer step. "
+                "Check batch size and gradient_accumulation_steps against the dataset size."
+            )
+
+        return metrics
+
+    def save_model(self, output_dir: str | None = None) -> str:
+        """Save the reward model and tokenizer."""
+        output_dir = output_dir or self.args.output_dir
+        os.makedirs(output_dir, exist_ok=True)
+        if hasattr(self.model, "save_pretrained"):
+            self.model.save_pretrained(output_dir)
+        else:
+            torch.save(self.model.state_dict(), os.path.join(output_dir, "model.pt"))
+        if hasattr(self.tokenizer, "save_pretrained"):
+            self.tokenizer.save_pretrained(output_dir)
+        logger.info(f"Reward model saved to {output_dir}")
+        return output_dir
+
+
+def create_rm_trainer(model: Any, tokenizer: Any, train_dataset: Any, **kwargs: Any) -> RMTrainer:
+    """Build an RMTrainer, passing unknown keyword arguments to RMConfig."""
+    config_fields = RMConfig.__dataclass_fields__
+    config_kwargs = {k: v for k, v in kwargs.items() if k in config_fields}
+    trainer_kwargs = {k: v for k, v in kwargs.items() if k not in config_fields}
+    return RMTrainer(
+        model=model,
+        tokenizer=tokenizer,
+        train_dataset=train_dataset,
+        args=RMConfig(**config_kwargs),
+        **trainer_kwargs,
+    )
+
+
+__all__ = ["RMConfig", "RMTrainer", "create_rm_trainer"]


### PR DESCRIPTION
Closes #125.

The library could SFT a model and could run GRPO, but had nothing in between: `models/reward_model.py` is architecture only, `PRMTrainer` is a stub (#74), and `cli/main.py:452` is `# TODO: Implement reward model training`. So the `--reward-model-path ./rm_checkpoint` in the README quick start had no way to be produced here, and a user had to train the RM in another library, which is how the RM and the policy end up with different tokenization and padding.

Both halves already existed: `models/loss.py:277 PairWiseLoss` is the Bradley-Terry objective and `data/datasets.py:184 PreferenceDataset` already yields tokenized `chosen`/`rejected` pairs. This is the loop between them.

Design notes worth reviewing:

- chosen and rejected are padded to one common length and scored in a **single** forward pass, so the split back into two reward vectors is a fixed halfway point rather than two ragged batches.
- a run that finishes with `global_step == 0` raises, matching the guard added in #67 for GRPO, rather than saving an untrained model and exiting 0.
- `pin_memory` follows CUDA availability, and the tokenizer is required up front since it supplies the pad token.

Eight tests, including one that trains a small model for 30 epochs and then scores a chosen and a rejected sequence **directly through the model**. That distinction matters: an earlier version of the test asserted on the trainer's own `reward_diff` metric and still passed when I swapped chosen and rejected inside `compute_loss`, because the metric is computed from the same swapped variables. The current test fails on that mutation.

Not in this PR: wiring `thinkrl reward` to this trainer. That command is one of the stubs #68 is rewriting in `cli/main.py`, so the CLI wiring is better as a follow-up once #68 lands, to avoid conflicting edits in the same block.