### PR TITLE
Apply the PRIME Eq. 5 sum for every gamma, not only gamma == 1.0

### DIFF
--- a/tests/test_algorithms/test_prime_advantages.py
+++ b/tests/test_algorithms/test_prime_advantages.py
@@ -1,0 +1,54 @@
+"""Regression test: PRIME must apply Equation 5 for every gamma, not only gamma == 1.0."""
+
+import torch
+import torch.nn as nn
+
+from thinkrl.algorithms.prime import PRIMEAlgorithm, PRIMEConfig
+
+
+class _TinyLM(nn.Module):
+    def __init__(self, vocab: int = 16, dim: int = 8):
+        super().__init__()
+        self.emb = nn.Embedding(vocab, dim)
+        self.head = nn.Linear(dim, vocab)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        return {"logits": self.head(self.emb(input_ids))}
+
+
+def _algorithm(gamma):
+    return PRIMEAlgorithm(policy_model=_TinyLM(), ref_model=_TinyLM(), config=PRIMEConfig(gamma=gamma))
+
+
+PROCESS = torch.tensor([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]])
+OUTCOME = torch.tensor([1.0, 0.0])
+MASK = torch.ones(2, 3)
+
+
+def _advantages(gamma):
+    return _algorithm(gamma).compute_advantages(PROCESS, OUTCOME, MASK, group_size=2)
+
+
+def test_undiscounted_case_is_the_reverse_cumulative_sum():
+    # Per-token RLOO residual is 1.0 on the first row; outcome residual adds a further 1.0.
+    torch.testing.assert_close(_advantages(1.0)[0], torch.tensor([4.0, 3.0, 2.0]))
+
+
+def test_discounted_case_applies_the_discount_rather_than_skipping_the_sum():
+    gamma = 0.9
+    advantages = _advantages(gamma)[0]
+
+    # A_t = d_t + gamma * A_{t+1} over a residual of 1.0 per token, plus the outcome term.
+    process = torch.tensor([1.0 + gamma * (1.0 + gamma * 1.0), 1.0 + gamma * 1.0, 1.0])
+    torch.testing.assert_close(advantages, process + 1.0)
+
+
+def test_discount_is_not_silently_dropped():
+    """The regression: gamma != 1.0 used to return the raw per-token residual."""
+    raw_residual = torch.tensor([2.0, 2.0, 2.0])
+    assert not torch.allclose(_advantages(0.9)[0], raw_residual)
+    assert not torch.allclose(_advantages(0.99)[0], raw_residual)
+
+
+def test_gamma_approaching_one_approaches_the_undiscounted_result():
+    torch.testing.assert_close(_advantages(0.999)[0], _advantages(1.0)[0], rtol=0, atol=0.01)

--- a/thinkrl/algorithms/prime.py
+++ b/thinkrl/algorithms/prime.py
@@ -218,17 +218,19 @@ class PRIMEAlgorithm(BaseRLHFAlgorithm):
         # A_process_t = r_phi_t - baseline_t
         adv_process = proc_r - loo_mean_proc
 
-        # Apply discount (gamma) - usually 1.0 for this paper
-        # If gamma < 1.0, we would need cumulative sum logic here.
-        # For simple sum (gamma=1), we can just sum the token advantages later for the return,
-        # but standard RLOO usually keeps token-level signals for token-level updates.
-        # Paper Eq 5 implies summation from t to T.
+        # Paper Eq 5: A_t = Sum_{s=t}^{T} gamma^(s-t) * (r_s - b_s)
         if self.config.gamma == 1.0:
-            # Simple accumulation from t to T
-            # We can use a simplified approach: just the token advantage
-            # Or strictly implement the sum: A_t = Sum_{s=t}^T (r_s - b_s)
-            # Efficient implementation: Flip, Cumsum, Flip
+            # Undiscounted case reduces to a reverse cumulative sum: flip, cumsum, flip.
             adv_process = torch.flip(torch.cumsum(torch.flip(adv_process, dims=[2]), dim=2), dims=[2])
+        else:
+            # A_t = d_t + gamma * A_{t+1}. Done as a backward recursion rather than a
+            # scaled cumsum because gamma ** seq_len underflows on long reasoning traces.
+            discounted = torch.zeros_like(adv_process)
+            running = torch.zeros_like(adv_process[:, :, 0])
+            for t in reversed(range(adv_process.size(2))):
+                running = adv_process[:, :, t] + self.config.gamma * running
+                discounted[:, :, t] = running
+            adv_process = discounted
 
         # 2. Outcome Reward Advantage (Sequence-level RLOO)
         # Shape: [G, K]


### PR DESCRIPTION
Closes #100.

The Equation 5 reverse cumulative sum was gated on `gamma == 1.0`. Any other value skipped the branch entirely, applying neither the discount nor the sum from t to T, so the advantage stayed as the raw per-token RLOO residual: `gamma=1.0` gave `[4, 3, 2]` where `gamma=0.99` gave `[2, 2, 2]`. The comment above the branch already noted the discounted path had not been written.

The discounted case now runs the `A_t = d_t + gamma * A_(t+1)` recursion. I used a backward loop rather than a scaled cumsum because `gamma ** seq_len` underflows on long reasoning traces, and the loop matches what `utils/metrics.py:compute_advantages` already does. The `gamma == 1.0` fast path is untouched.

Four tests, three failing on `main`, including one that checks `gamma=0.999` converges on the undiscounted result.
