### PR TITLE
Validate PRIMEConfig and reject group sizes that produce NaN advantages

### DIFF
--- a/tests/test_algorithms/test_prime_config_validation.py
+++ b/tests/test_algorithms/test_prime_config_validation.py
@@ -1,0 +1,63 @@
+"""Regression test: PRIMEConfig rejects values it cannot honour instead of silently degrading."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from thinkrl.algorithms.prime import PRIMEAlgorithm, PRIMEConfig
+
+
+class _TinyLM(nn.Module):
+    def __init__(self, vocab: int = 16, dim: int = 8):
+        super().__init__()
+        self.emb = nn.Embedding(vocab, dim)
+        self.head = nn.Linear(dim, vocab)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        return {"logits": self.head(self.emb(input_ids))}
+
+
+def test_defaults_still_construct():
+    assert PRIMEConfig().advantage_estimator == "rloo"
+
+
+def test_unimplemented_advantage_estimator_is_rejected():
+    with pytest.raises(NotImplementedError, match="rloo"):
+        PRIMEConfig(advantage_estimator="reinforce")
+
+
+def test_unknown_advantage_estimator_is_rejected():
+    with pytest.raises(ValueError, match="advantage_estimator"):
+        PRIMEConfig(advantage_estimator="gae")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"num_generations_per_prompt": 1},
+        {"n_epochs": 0},
+        {"batch_size": 0},
+        {"clip_epsilon": 0.0},
+        {"clip_epsilon": 1.0},
+        {"gamma": 0.0},
+        {"gamma": 1.5},
+        {"temperature": 0.0},
+    ],
+)
+def test_out_of_range_values_are_rejected(kwargs):
+    with pytest.raises(ValueError):
+        PRIMEConfig(**kwargs)
+
+
+def test_group_size_of_one_raises_instead_of_producing_nan():
+    algorithm = PRIMEAlgorithm(policy_model=_TinyLM(), ref_model=_TinyLM(), config=PRIMEConfig())
+
+    with pytest.raises(ValueError, match="group_size"):
+        algorithm.compute_advantages(torch.ones(1, 3), torch.ones(1), torch.ones(1, 3), group_size=1)
+
+
+def test_indivisible_batch_raises():
+    algorithm = PRIMEAlgorithm(policy_model=_TinyLM(), ref_model=_TinyLM(), config=PRIMEConfig())
+
+    with pytest.raises(ValueError, match="divisible"):
+        algorithm.compute_advantages(torch.ones(3, 3), torch.ones(3), torch.ones(3, 3), group_size=2)

--- a/thinkrl/algorithms/prime.py
+++ b/thinkrl/algorithms/prime.py
@@ -61,6 +61,32 @@ class PRIMEConfig:
     max_new_tokens: int = 512
     temperature: float = 1.0
 
+    def __post_init__(self):
+        if self.advantage_estimator not in ("rloo", "reinforce"):
+            raise ValueError(
+                f"advantage_estimator must be 'rloo' or 'reinforce', got {self.advantage_estimator!r}"
+            )
+        if self.advantage_estimator == "reinforce":
+            raise NotImplementedError(
+                "Only the 'rloo' advantage estimator is implemented. "
+                "'reinforce' is accepted by the config but has no code path."
+            )
+        if self.num_generations_per_prompt < 2:
+            raise ValueError(
+                "num_generations_per_prompt must be >= 2: the RLOO baseline is a leave-one-out "
+                f"mean over the group and divides by K - 1, got {self.num_generations_per_prompt}"
+            )
+        if self.n_epochs < 1:
+            raise ValueError(f"n_epochs must be >= 1, got {self.n_epochs}")
+        if self.batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {self.batch_size}")
+        if not 0 < self.clip_epsilon < 1:
+            raise ValueError(f"clip_epsilon must be in (0, 1), got {self.clip_epsilon}")
+        if not 0 < self.gamma <= 1:
+            raise ValueError(f"gamma must be in (0, 1], got {self.gamma}")
+        if self.temperature <= 0:
+            raise ValueError(f"temperature must be positive, got {self.temperature}")
+
 
 class PRIMEAlgorithm(BaseRLHFAlgorithm):
     """
@@ -204,6 +230,16 @@ class PRIMEAlgorithm(BaseRLHFAlgorithm):
         # Reshape to [Group, Sample, Seq] for broadcasting
         # Assuming batch is perfectly divisible by group_size (K)
         batch_size, seq_len = implicit_rewards.shape
+        if group_size < 2:
+            raise ValueError(
+                "group_size must be >= 2: the leave-one-out baseline divides by group_size - 1, "
+                f"so group_size={group_size} produces NaN advantages"
+            )
+        if batch_size % group_size:
+            raise ValueError(
+                f"batch_size {batch_size} is not divisible by group_size {group_size}, "
+                "so the rewards cannot be reshaped into complete groups"
+            )
         num_groups = batch_size // group_size
 
         # 1. Process Reward Advantage (Token-level RLOO)


### PR DESCRIPTION
Closes #101.

`PRIMEConfig` had no `__post_init__`, so nothing checked any field. `group_size=1` made the leave-one-out baseline divide by zero and returned an all-NaN advantage tensor without raising, which surfaces as a NaN loss several frames from the cause. `advantage_estimator` was documented as `rloo|reinforce` and never read, so `"reinforce"` silently ran RLOO.

Adds range checks for the numeric fields, and rejects `group_size < 2` and batch sizes that do not divide into whole groups at the point of use, since those arrive as call arguments rather than from config. `DAPOConfig` already asserts the same group-size condition.

For `advantage_estimator` I chose to raise `NotImplementedError` rather than implement the REINFORCE variant, on the grounds that a loud failure is the honest state and the paper reports RLOO as the better estimator anyway. Say the word if you would rather have it implemented or the field removed.

Thirteen tests. The full suite goes from 738 to 751 passed with no new failures.
