### PR TITLE
Make DAPOConfig.dynamic_sampling reachable from the training path

### DIFF
--- a/tests/test_algorithms/test_dapo_dynamic_sampling.py
+++ b/tests/test_algorithms/test_dapo_dynamic_sampling.py
@@ -1,0 +1,80 @@
+"""Regression test: DAPOConfig.dynamic_sampling must actually change what training sees."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from thinkrl.algorithms.dapo import DAPOAlgorithm, DAPOConfig
+
+
+class _TinyLM(nn.Module):
+    def __init__(self, vocab: int = 16, dim: int = 8):
+        super().__init__()
+        self.emb = nn.Embedding(vocab, dim)
+        self.head = nn.Linear(dim, vocab)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        return {"logits": self.head(self.emb(input_ids))}
+
+
+def _config(**kwargs):
+    defaults = dict(group_size=2, n_epochs=1, min_batch_size=2, use_overlong_punishment=False)
+    return DAPOConfig(**{**defaults, **kwargs})
+
+
+def _batch(rewards):
+    n = len(rewards)
+    return {
+        "input_ids": torch.randint(0, 16, (n, 3)),
+        "attention_mask": torch.ones(n, 3, dtype=torch.long),
+        "labels": torch.randint(0, 16, (n, 3)),
+        "rewards": torch.tensor(rewards),
+    }
+
+
+def test_disabled_by_default_leaves_the_batch_alone():
+    algorithm = DAPOAlgorithm(policy_model=_TinyLM(), config=_config())
+    assert algorithm.config.dynamic_sampling is False
+
+    metrics = algorithm.train_on_rollout(_batch([1.0, 0.0]))
+    assert metrics
+
+
+def test_enabled_without_a_sampler_raises_instead_of_ignoring_the_flag():
+    algorithm = DAPOAlgorithm(policy_model=_TinyLM(), config=_config(dynamic_sampling=True))
+
+    with pytest.raises(ValueError, match="sample_fn"):
+        algorithm.train_on_rollout(_batch([1.0, 0.0]))
+
+
+def test_enabled_resamples_until_a_group_has_reward_variance():
+    algorithm = DAPOAlgorithm(policy_model=_TinyLM(), config=_config(dynamic_sampling=True))
+
+    # First two draws are degenerate (both members of the group score the same), so they
+    # carry no gradient signal and must be discarded rather than trained on.
+    draws = [[0.0, 0.0], [1.0, 1.0], [1.0, 0.0]]
+    calls = []
+
+    def sample_fn():
+        rewards = draws[len(calls)] if len(calls) < len(draws) else draws[-1]
+        calls.append(rewards)
+        batch = _batch(rewards)
+        return {k: v for k, v in batch.items() if k != "rewards"}, batch["rewards"]
+
+    metrics = algorithm.train_on_rollout(_batch([0.0, 0.0]), sample_fn=sample_fn)
+
+    assert len(calls) == 3, "degenerate draws were not discarded"
+    assert metrics
+
+
+def test_exhausting_the_attempt_budget_raises():
+    algorithm = DAPOAlgorithm(
+        policy_model=_TinyLM(), config=_config(dynamic_sampling=True, max_sampling_attempts=2)
+    )
+
+    def always_degenerate():
+        batch = _batch([1.0, 1.0])
+        return {k: v for k, v in batch.items() if k != "rewards"}, batch["rewards"]
+
+    with pytest.raises(RuntimeError, match="non-zero reward variance"):
+        algorithm.train_on_rollout(_batch([0.0, 0.0]), sample_fn=always_degenerate)

--- a/thinkrl/algorithms/dapo.py
+++ b/thinkrl/algorithms/dapo.py
@@ -23,6 +23,7 @@ Author: Archit Sood @ EllanorAI
 from dataclasses import dataclass
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.optim import Optimizer
@@ -569,6 +570,7 @@ class DAPOAlgorithm(BaseRLHFAlgorithm):
     def train_on_rollout(
         self,
         batch: dict[str, torch.Tensor],
+        sample_fn=None,
     ) -> list[dict[str, float]]:
         """
         Multi-epoch training on a single rollout batch (Algorithm 1, lines 10-11).
@@ -577,10 +579,16 @@ class DAPOAlgorithm(BaseRLHFAlgorithm):
 
         Args:
             batch: Rollout batch with input_ids, attention_mask, labels, rewards
+            sample_fn: Required when config.dynamic_sampling is set. Callable returning
+                (samples_dict, rewards_tensor); it is re-invoked until enough groups with
+                non-zero reward variance have been collected (Section 3.2).
 
         Returns:
             List of metrics dicts, one per epoch
         """
+        if self.config.dynamic_sampling:
+            batch = self._resample_batch(batch, sample_fn)
+
         # Use pre-computed old_log_probs if available (e.g. from vLLM),
         # otherwise compute via forward pass (θ_old frozen)
         if "old_log_probs" in batch:
@@ -601,6 +609,35 @@ class DAPOAlgorithm(BaseRLHFAlgorithm):
                 break
 
         return all_metrics
+
+    def _resample_batch(
+        self,
+        batch: dict[str, torch.Tensor],
+        sample_fn,
+    ) -> dict[str, torch.Tensor]:
+        """Replace the supplied batch with one collected under dynamic sampling."""
+        if dist.is_available() and dist.is_initialized():
+            raise RuntimeError(
+                "dynamic_sampling is not safe under distributed training: ranks would "
+                "resample independently and desynchronise. Set dynamic_sampling=False."
+            )
+        if sample_fn is None:
+            raise ValueError(
+                "dynamic_sampling=True requires a sample_fn so groups with zero reward "
+                "variance can be replaced. Pass sample_fn to train_on_rollout, or set "
+                "dynamic_sampling=False to train on the batch as given."
+            )
+
+        resampled = self.process_rollout_with_dynamic_sampling(
+            sample_fn=sample_fn,
+            batch_size=batch["rewards"].size(0),
+        )
+        if resampled is None:
+            raise RuntimeError(
+                f"Dynamic sampling could not collect {batch['rewards'].size(0)} samples with "
+                f"non-zero reward variance in {self.config.max_sampling_attempts} attempts."
+            )
+        return resampled
 
     def process_rollout_with_dynamic_sampling(
         self,


### PR DESCRIPTION
Closes #105.

`DAPOConfig.dynamic_sampling` was declared and never read, so `DynamicSamplingBuffer` and `process_rollout_with_dynamic_sampling` were reachable only by calling them directly, and the shipped `train_on_rollout` never consulted the flag. Dynamic sampling is one of the four contributions the DAPO paper names and the only one not wired.

`train_on_rollout` now takes an optional `sample_fn` and, when the flag is set, collects the batch through the buffer so groups with zero reward variance are discarded rather than trained on. Two deliberate failure modes: enabling the flag without a `sample_fn` raises rather than silently ignoring it, and enabling it while a process group is initialised raises, since `DynamicSamplingBuffer`'s own docstring warns it is not DDP-safe and independent resampling per rank would desynchronise.

The signature addition is optional and defaults to `None`, so existing callers are unaffected. Four tests, three failing on `main`.
