### PR TITLE
Add create_vapo and export it alongside the other algorithm factories

### DIFF
--- a/tests/test_algorithms/test_algorithm_factories.py
+++ b/tests/test_algorithms/test_algorithm_factories.py
@@ -1,0 +1,56 @@
+"""Every registered algorithm that can be constructed should have a working factory."""
+
+import torch.nn as nn
+
+import thinkrl.algorithms as algorithms
+from thinkrl.algorithms import create_vapo
+from thinkrl.algorithms.vapo import VAPOAlgorithm
+
+
+class _TinyLM(nn.Module):
+    def __init__(self, vocab: int = 16, dim: int = 8):
+        super().__init__()
+        self.emb = nn.Embedding(vocab, dim)
+        self.head = nn.Linear(dim, vocab)
+        self.vhead = nn.Linear(dim, 1)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        hidden = self.emb(input_ids)
+        return {"logits": self.head(hidden), "values": self.vhead(hidden).squeeze(-1)}
+
+
+def test_create_vapo_returns_a_configured_algorithm():
+    algorithm = create_vapo(policy_model=_TinyLM(), learning_rate=5e-6, n_epochs=3)
+
+    assert isinstance(algorithm, VAPOAlgorithm)
+    assert algorithm.config.learning_rate == 5e-6
+    assert algorithm.config.n_epochs == 3
+
+
+def test_create_vapo_forwards_config_kwargs():
+    algorithm = create_vapo(policy_model=_TinyLM(), adaptive_gae_alpha=0.1)
+
+    assert algorithm.config.adaptive_gae_alpha == 0.1
+
+
+def test_create_vapo_is_exported():
+    assert "create_vapo" in algorithms.__all__
+    assert algorithms.create_vapo is create_vapo
+
+
+def test_every_non_stub_registered_algorithm_has_a_factory():
+    """Matches on the class the factory builds, so registry aliases do not create false gaps."""
+    # KTO, ORPO and RLOO raise NotImplementedError from __init__ (see #76); they are
+    # excluded here rather than silently passing.
+    stubs = {"kto", "orpo", "rloo"}
+
+    # Some modules use postponed annotations, so the return type may be a string.
+    built = {
+        getattr(returns, "__name__", returns)
+        for name in dir(algorithms)
+        if name.startswith("create_")
+        for returns in [getattr(algorithms, name).__annotations__.get("return")]
+    }
+
+    registered = {cls.__name__ for name, cls in algorithms.ALGORITHMS.items() if name not in stubs}
+    assert registered - built == set()

--- a/thinkrl/algorithms/__init__.py
+++ b/thinkrl/algorithms/__init__.py
@@ -40,7 +40,7 @@ from thinkrl.algorithms.reinforce import REINFORCEAlgorithm, REINFORCEConfig, cr
 from thinkrl.algorithms.reinforce_pp import REINFORCEPPAlgorithm, REINFORCEPPConfig, create_reinforce_pp
 from thinkrl.algorithms.rloo import RLOOAlgorithm, RLOOConfig, create_rloo
 from thinkrl.algorithms.star import STaRAlgorithm, STaRConfig, create_star
-from thinkrl.algorithms.vapo import VAPOAlgorithm, VAPOConfig
+from thinkrl.algorithms.vapo import VAPOAlgorithm, VAPOConfig, create_vapo
 
 
 # Algorithm registry for factory pattern
@@ -123,6 +123,7 @@ __all__ = [
     # VAPO
     "VAPOAlgorithm",
     "VAPOConfig",
+    "create_vapo",
     # REINFORCE
     "REINFORCEAlgorithm",
     "REINFORCEConfig",

--- a/thinkrl/algorithms/vapo.py
+++ b/thinkrl/algorithms/vapo.py
@@ -434,3 +434,46 @@ class VAPOAlgorithm(BaseRLHFAlgorithm):
             self.value_optimizer.step()
 
         return {k: v.item() if isinstance(v, torch.Tensor) else v for k, v in loss_dict.items()}
+
+
+def create_vapo(
+    policy_model: nn.Module,
+    value_model: nn.Module | None = None,
+    ref_model: nn.Module | None = None,
+    optimizer: Optimizer | None = None,
+    value_optimizer: Optimizer | None = None,
+    learning_rate: float = 1e-6,
+    n_epochs: int = 2,
+    batch_size: int = 64,
+    **kwargs,
+) -> VAPOAlgorithm:
+    """
+    Factory function to create a VAPOAlgorithm instance.
+
+    Args:
+        policy_model: The policy model to optimize
+        value_model: Optional separate critic
+        ref_model: Optional reference model
+        optimizer: Optional optimizer for the policy
+        value_optimizer: Optional optimizer for the critic
+        learning_rate: Learning rate
+        n_epochs: Number of optimization epochs per rollout
+        batch_size: Mini-batch size
+        **kwargs: Additional args for VAPOConfig
+
+    Returns:
+        Configured VAPOAlgorithm
+    """
+    config = VAPOConfig(learning_rate=learning_rate, n_epochs=n_epochs, batch_size=batch_size, **kwargs)
+
+    return VAPOAlgorithm(
+        policy_model=policy_model,
+        value_model=value_model,
+        ref_model=ref_model,
+        optimizer=optimizer,
+        value_optimizer=value_optimizer,
+        config=config,
+    )
+
+
+__all__ = ["VAPOAlgorithm", "VAPOConfig", "create_vapo"]


### PR DESCRIPTION
Closes #110.

VAPO was the only entry in `ALGORITHMS` without a `create_*` helper, so `from thinkrl.algorithms import create_vapo` raised `ImportError` while every sibling import succeeded. `create_vapo` follows the shape of `create_ppo`, which takes the same policy, value and reference model triple.

The added coverage test matches registry entries against the class each factory builds rather than against the factory name, so the aliases `drgrpo` and `reinforce++` do not read as gaps, and a future algorithm added without a factory does. KTO, ORPO and RLOO are excluded explicitly with a pointer to #76 rather than passing silently.
