### PR TITLE
Use the population standard deviation in the single-process advantage normalization

### DIFF
--- a/tests/test_algorithms/test_reinforce_pp_statistics.py
+++ b/tests/test_algorithms/test_reinforce_pp_statistics.py
@@ -1,0 +1,62 @@
+"""Regression test: advantage normalization must not depend on world size."""
+
+import torch
+import torch.nn as nn
+
+from thinkrl.algorithms.reinforce_pp import REINFORCEPPAlgorithm, REINFORCEPPConfig
+
+
+class _TinyLM(nn.Module):
+    def __init__(self, vocab: int = 16, dim: int = 8):
+        super().__init__()
+        self.emb = nn.Embedding(vocab, dim)
+        self.head = nn.Linear(dim, vocab)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        return {"logits": self.head(self.emb(input_ids))}
+
+
+def _algorithm():
+    return REINFORCEPPAlgorithm(policy_model=_TinyLM(), ref_model=_TinyLM(), config=REINFORCEPPConfig())
+
+
+def _population_std(tensor):
+    """What the distributed branch computes: sqrt(E[x^2] - E[x]^2)."""
+    return torch.sqrt(torch.clamp((tensor**2).mean() - tensor.mean() ** 2, min=1e-8))
+
+
+def test_single_process_std_matches_the_distributed_formula():
+    algorithm = _algorithm()
+    values = torch.tensor([1.0, 2.0, 3.0, 10.0])
+
+    _, std = algorithm._global_statistics(values)
+
+    torch.testing.assert_close(std, _population_std(values))
+
+
+def test_small_batches_do_not_drift_from_the_distributed_formula():
+    """The n vs n-1 gap is widest exactly where per-device batches usually sit."""
+    algorithm = _algorithm()
+
+    for n in (4, 8, 16):
+        values = torch.arange(float(n))
+        _, std = algorithm._global_statistics(values)
+        torch.testing.assert_close(std, _population_std(values), rtol=1e-6, atol=1e-6)
+
+
+def test_masking_still_selects_valid_elements():
+    algorithm = _algorithm()
+    values = torch.tensor([1.0, 2.0, 3.0, 999.0])
+    mask = torch.tensor([1, 1, 1, 0])
+
+    mean, std = algorithm._global_statistics(values, mask)
+
+    torch.testing.assert_close(mean, torch.tensor(2.0))
+    torch.testing.assert_close(std, _population_std(values[:3]))
+
+
+def test_degenerate_inputs_are_still_handled():
+    algorithm = _algorithm()
+
+    assert algorithm._global_statistics(torch.tensor([]))[1].item() == 1.0
+    assert algorithm._global_statistics(torch.tensor([5.0]))[1].item() == 1.0

--- a/thinkrl/algorithms/reinforce_pp.py
+++ b/thinkrl/algorithms/reinforce_pp.py
@@ -178,9 +178,11 @@ class REINFORCEPPAlgorithm(BaseRLHFAlgorithm):
         if tensor.numel() <= 1:
             return tensor.mean(), torch.tensor(1.0, device=tensor.device)
 
-        # If not distributed, standard mean/std
+        # If not distributed, standard mean/std. correction=0 gives the population standard
+        # deviation, matching the distributed branch below; torch defaults to correction=1,
+        # which would normalize by a different divisor depending on world size.
         if not dist.is_initialized():
-            return tensor.mean(), tensor.std()
+            return tensor.mean(), tensor.std(correction=0)
 
         # Distributed Global Statistics
         # We compute global sum, global sq_sum, and global count


### PR DESCRIPTION
Closes #112.

`_global_statistics` returned `tensor.std()` in the single-process branch, which defaults to `correction=1` and divides by n-1, while the distributed branch computes `sqrt(E[x^2] - E[x]^2)` and divides by n. The same batch of advantages was therefore normalized differently depending on world size, by a factor of `sqrt(n/(n-1))`: 6 percent at n=8 and 12 percent at n=4, both ordinary per-device batch sizes for long-sequence reasoning work.

I made the single-process branch match the distributed one rather than the other way round, since the distributed path would otherwise need an extra correction term. Global advantage normalization is one of the two things the module docstring names as a REINFORCE++ feature, so it seemed worth having it mean the same thing in both modes.

Four tests, three failing on `main`, including one covering the masked path and one covering the empty and single-element cases.
