### PR TITLE
Guard config from_dict against empty and null sections

### DIFF
--- a/tests/test_config/test_config_none_guard.py
+++ b/tests/test_config/test_config_none_guard.py
@@ -1,0 +1,15 @@
+"""CFG-2/OBS-2: from_dict must not crash with AttributeError on empty/null-section configs."""
+import pytest
+from thinkrl.config.base import ThinkRLConfig
+
+
+def test_empty_config_raises_clear_error():
+    with pytest.raises(ValueError, match="empty"):
+        ThinkRLConfig.from_dict(None)
+
+
+def test_null_sections_default_to_empty():
+    # `model:` / `distributed:` present but null must not crash
+    cfg = ThinkRLConfig.from_dict({"model": None, "distributed": None, "algorithm": None})
+    assert cfg.model is not None
+    assert cfg.distributed is not None

--- a/thinkrl/config/base.py
+++ b/thinkrl/config/base.py
@@ -218,11 +218,18 @@ class ThinkRLConfig:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ThinkRLConfig:
         """Create config from dictionary."""
+        # An empty or comment-only YAML/JSON parses to None; fail with a clear
+        # message instead of an AttributeError deep inside the parser.
+        if data is None:
+            raise ValueError("Config is empty (parsed to None). Provide a non-empty YAML/JSON file.")
+
+        # `data.get(k, {})` still returns None when the key is present but null
+        # (e.g. `model:` with nothing under it), so coalesce each section to {}.
         # Parse nested configs
-        model = ModelConfig(**data.get("model", {}))
+        model = ModelConfig(**(data.get("model") or {}))
 
         # Dynamic Algorithm Config Loading
-        algo_data = data.get("algorithm", {})
+        algo_data = data.get("algorithm") or {}
         # If algorithm is already an object, assume it's valid
         if not isinstance(algo_data, dict):
             algorithm = algo_data
@@ -257,9 +264,9 @@ class ThinkRLConfig:
             except Exception as e:
                 logger.warning(f"Failed to load algorithm config for '{algo_name}': {e}. Falling back to dict.")
                 algorithm = algo_data
-        distributed = DistributedConfig(**data.get("distributed", {}))
-        data_config = DataConfig(**data.get("data", {}))
-        logging_config = LoggingConfig(**data.get("logging", {}))
+        distributed = DistributedConfig(**(data.get("distributed") or {}))
+        data_config = DataConfig(**(data.get("data") or {}))
+        logging_config = LoggingConfig(**(data.get("logging") or {}))
 
         peft = None
         if "peft" in data and data["peft"]:


### PR DESCRIPTION
Closes #153.

An empty or comment-only YAML parses to `None`, so `data.get("model", {})` raised `AttributeError: 'NoneType' object has no attribute 'get'` from inside `from_dict` rather than saying the file was empty. A present-but-null section (`model:` with nothing under it) failed separately, because `.get(k, {})` returns `None` when the key exists and `**None` then raises `TypeError`.

`from_dict` now raises a `ValueError` saying the config parsed to None, and each of the five sections is coalesced with `or {}` so a null section behaves exactly like an absent one. Nothing else changes: a populated config takes the same path it did before.

Two tests, both failing on `main`: the empty document, and a config whose `model:` key is present and null.
