### PR TITLE
Report configuration fields that nothing reads, and default trust_remote_code to off

### DIFF
--- a/tests/test_config/test_unhonoured_fields.py
+++ b/tests/test_config/test_unhonoured_fields.py
@@ -1,0 +1,80 @@
+"""Regression test: config fields nothing reads must say so instead of silently doing nothing."""
+
+import dataclasses
+
+import pytest
+
+from thinkrl.config.base import UNHONOURED, DataConfig, LoggingConfig, ModelConfig, PeftConfig, ThinkRLConfig
+
+
+def test_trust_remote_code_is_off_by_default():
+    """It executes code from the model repository, so the safe value is the default."""
+    assert ModelConfig().trust_remote_code is False
+
+
+def test_defaults_report_nothing():
+    assert ThinkRLConfig().unhonoured_fields() == []
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value"),
+    [
+        ("model", "load_in_8bit", True),
+        ("data", "streaming", True),
+        ("data", "num_workers", 8),
+        ("logging", "save_every_n_steps", 50),
+        ("logging", "wandb_entity", "some-team"),
+        ("distributed", "backend", "gloo"),
+    ],
+)
+def test_setting_an_unhonoured_field_is_reported(section, field, value):
+    config = ThinkRLConfig()
+    setattr(getattr(config, section), field, value)
+
+    messages = config.unhonoured_fields()
+
+    assert any(f"{section}.{field}" in message for message in messages), messages
+
+
+def test_report_explains_why_rather_than_only_naming_the_field():
+    config = ThinkRLConfig(model=ModelConfig(load_in_8bit=True))
+
+    (message,) = config.unhonoured_fields()
+
+    assert "full precision" in message
+
+
+def test_validate_still_returns_real_errors_only():
+    """The report is a warning, not a validation failure, so a run is not blocked by it."""
+    config = ThinkRLConfig(data=DataConfig(streaming=True))
+
+    assert config.validate() == []
+
+
+def test_every_listed_field_exists():
+    """Guards the list against drift: a renamed or removed field must not sit here unnoticed."""
+    # peft is optional and defaults to None, so it has to be supplied to be inspected.
+    config = ThinkRLConfig(peft=PeftConfig())
+    for section_name, field_name, _reason in UNHONOURED:
+        section = getattr(config, section_name, None)
+        assert section is not None, f"unknown section {section_name}"
+        names = {f.name for f in dataclasses.fields(section)}
+        assert field_name in names, f"{section_name}.{field_name} is listed but does not exist"
+
+
+def test_list_covers_the_logging_fields_that_have_no_reader():
+    listed = {field for section, field, _ in UNHONOURED if section == "logging"}
+    declared = {f.name for f in dataclasses.fields(LoggingConfig())}
+
+    assert listed <= declared
+    assert "save_every_n_steps" in listed
+
+
+def test_optional_peft_section_is_reported_when_present():
+    config = ThinkRLConfig(peft=PeftConfig(auto_target_modules=False))
+
+    assert any("peft.auto_target_modules" in message for message in config.unhonoured_fields())
+
+
+def test_absent_peft_section_is_skipped_rather_than_crashing():
+    assert ThinkRLConfig(peft=None).unhonoured_fields() == []

--- a/thinkrl/config/base.py
+++ b/thinkrl/config/base.py
@@ -31,6 +31,35 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+# Fields the configuration accepts and that no code path reads. Each entry is
+# (section, field, why). Remove an entry when the field is wired; the accompanying test
+# fails if an entry names a field that no longer exists, so the list cannot drift.
+UNHONOURED = [
+    ("model", "load_in_8bit", "8-bit loading is not implemented; the model loads at full precision"),
+    ("model", "bnb_4bit_compute_dtype", "bitsandbytes quantization is not wired into the model loader"),
+    ("model", "bnb_4bit_quant_type", "bitsandbytes quantization is not wired into the model loader"),
+    ("model", "ref_model_name_or_path", "the reference model is always constructed by the caller"),
+    ("model", "share_ref_weights", "reference-weight sharing is not implemented"),
+    ("data", "dataset_split", "the split is chosen by the caller building the dataset"),
+    ("data", "eval_split", "there is no evaluation loop to consume it"),
+    ("data", "eval_batch_size", "there is no evaluation loop to consume it"),
+    ("data", "num_workers", "the trainers construct their own DataLoader"),
+    ("data", "streaming", "streaming datasets are not implemented"),
+    ("logging", "wandb_entity", "wandb.init is called without the entity"),
+    ("logging", "wandb_name", "wandb.init is called without the run name"),
+    ("logging", "wandb_tags", "wandb.init is called without tags"),
+    ("logging", "tensorboard_dir", "the TensorBoard writer uses its own path"),
+    ("logging", "eval_every_n_steps", "there is no evaluation loop to schedule"),
+    ("logging", "save_every_n_steps", "the trainers take their save interval as an argument"),
+    ("logging", "save_total_limit", "checkpoint rotation is configured on CheckpointManager"),
+    ("logging", "log_level", "logging is configured through setup_logging, not this field"),
+    ("distributed", "backend", "the process group backend is chosen by the launcher"),
+    ("distributed", "master_addr", "the address comes from the environment"),
+    ("distributed", "master_port", "the port comes from the environment"),
+    ("peft", "auto_target_modules", "target-module inference is not implemented"),
+]
+
+
 @dataclass
 class ModelConfig:
     """Model configuration."""
@@ -52,7 +81,9 @@ class ModelConfig:
     bnb_4bit_quant_type: str = "nf4"
 
     # Loading
-    trust_remote_code: bool = True
+    # Executes code shipped with the model repository. Off by default; turn it on only
+    # for models that require it and sources you trust.
+    trust_remote_code: bool = False
     device_map: str = "auto"
 
     # Reference model
@@ -362,7 +393,33 @@ class ThinkRLConfig:
                 f"({self.data.max_prompt_length + self.data.max_response_length})"
             )
 
+        for message in self.unhonoured_fields():
+            logger.warning(message)
+
         return errors
+
+    def unhonoured_fields(self) -> list[str]:
+        """Report fields that are set to a non-default value and that nothing reads.
+
+        These fields parse, type-check and then do nothing, which is worse than a missing
+        field because the failure is invisible: `load_in_8bit: true` loads at full precision
+        and reads as a model-size problem, `use_lora: true` runs a full fine-tune and reads
+        as a too-small GPU. Until each one is wired, saying so is the honest behaviour.
+
+        Entries are removed from UNHONOURED as the corresponding feature lands.
+        """
+        messages = []
+        for section_name, field_name, reason in UNHONOURED:
+            section = getattr(self, section_name, None)
+            if section is None:
+                continue
+            current = getattr(section, field_name, None)
+            default = getattr(type(section)(), field_name, None)
+            if current != default:
+                messages.append(
+                    f"{section_name}.{field_name}={current!r} has no effect: {reason}"
+                )
+        return messages
 
 
 def load_config(path: str | Path) -> ThinkRLConfig:


### PR DESCRIPTION
Closes #102.

Twenty-two fields across the configuration dataclasses parse, type-check and then do nothing. The failure is invisible in a way that actively misdirects: `load_in_8bit: true` loads at full precision and reads as a model-size problem, `use_lora: true` runs a full fine-tune and reads as a too-small GPU.

Worth saying plainly: the reason so many are dead is that nothing consumes a `ThinkRLConfig` at all. `cli/main.py` loads it, validates it, prints it, and then hits `# TODO: Implement actual training loop` at line 115. So I did not wire the fields into a runtime that does not exist yet. What this does instead is make them audible: `unhonoured_fields()` names any field set away from its default and says why it has no effect, and `validate()` logs those before returning. They stay warnings rather than errors, so no run is blocked by one.

The list carries a reason per entry, and a test asserts every listed field still exists, so it cannot drift as fields get wired or renamed. Entries come off the list as features land.

Also flips `ModelConfig.trust_remote_code` from `True` to `False`. It is currently unread so nothing changes today, but every other `trust_remote_code` in the library defaults to `False`, and whoever wires this one up should not inherit arbitrary code execution as the default.

Fourteen tests. Suite 752 passed against a 738 baseline.
