### PR TITLE
Implement resume_from_checkpoint in SFTTrainer instead of ignoring it

### DIFF
--- a/tests/test_training/test_sft_resume.py
+++ b/tests/test_training/test_sft_resume.py
@@ -1,0 +1,95 @@
+"""Regression test: resume_from_checkpoint must actually restore the run."""
+
+import pytest
+import torch
+from transformers import GPT2Config, GPT2LMHeadModel
+
+from thinkrl.training.sft_trainer import TRAINER_STATE_FILE, SFTConfig, SFTTrainer
+
+
+def _model():
+    return GPT2LMHeadModel(GPT2Config(n_layer=1, n_head=1, n_embd=8, n_positions=16, vocab_size=32))
+
+
+def _trainer(tmp_path):
+    trainer = SFTTrainer(
+        model=_model(),
+        args=SFTConfig(output_dir=str(tmp_path), num_train_epochs=3),
+        train_dataset=[{"input_ids": [1, 2, 3], "labels": [1, 2, 3]}],
+    )
+    trainer.optimizer = torch.optim.AdamW(trainer.model.parameters(), lr=1e-4)
+    trainer.scheduler = torch.optim.lr_scheduler.StepLR(trainer.optimizer, step_size=1)
+    return trainer
+
+
+def test_save_model_writes_the_trainer_state(tmp_path):
+    trainer = _trainer(tmp_path)
+    trainer.global_step = 42
+    trainer.epoch = 1
+
+    trainer.save_model(str(tmp_path / "checkpoint-42"))
+
+    assert (tmp_path / "checkpoint-42" / TRAINER_STATE_FILE).exists()
+
+
+def test_resume_restores_step_epoch_and_optimizer(tmp_path):
+    saved = _trainer(tmp_path)
+    saved.global_step = 42
+    saved.epoch = 1
+    # Take one real optimizer step so the saved state is non-trivial.
+    loss = saved.model(input_ids=torch.tensor([[1, 2, 3]]), labels=torch.tensor([[1, 2, 3]])).loss
+    loss.backward()
+    saved.optimizer.step()
+    saved.save_model(str(tmp_path / "checkpoint-42"))
+
+    resumed = _trainer(tmp_path)
+    assert resumed.global_step == 0
+
+    resumed._load_trainer_state(str(tmp_path / "checkpoint-42"))
+
+    assert resumed.global_step == 42
+    assert resumed.start_epoch == 1
+    assert resumed.optimizer.state_dict()["state"], "optimizer moments were not restored"
+
+
+def test_resume_restores_the_weights(tmp_path):
+    saved = _trainer(tmp_path)
+    with torch.no_grad():
+        saved.model.transformer.wte.weight.fill_(0.25)
+    saved.save_model(str(tmp_path / "checkpoint-1"))
+
+    resumed = _trainer(tmp_path)
+    assert not torch.allclose(resumed.model.transformer.wte.weight, torch.full_like(resumed.model.transformer.wte.weight, 0.25))
+
+    resumed._load_trainer_state(str(tmp_path / "checkpoint-1"))
+
+    torch.testing.assert_close(
+        resumed.model.transformer.wte.weight,
+        torch.full_like(resumed.model.transformer.wte.weight, 0.25),
+    )
+
+
+def test_missing_directory_raises_rather_than_restarting(tmp_path):
+    trainer = _trainer(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        trainer._load_trainer_state(str(tmp_path / "nope"))
+
+
+def test_checkpoint_without_trainer_state_raises(tmp_path):
+    """A bare save_pretrained directory cannot restore a run, so it must not pretend to."""
+    trainer = _trainer(tmp_path)
+    bare = tmp_path / "bare"
+    trainer.model.save_pretrained(str(bare))
+
+    with pytest.raises(FileNotFoundError, match=TRAINER_STATE_FILE):
+        trainer._load_trainer_state(str(bare))
+
+
+def test_train_signature_argument_is_read():
+    """The regression: the parameter used to appear only in the signature and docstring."""
+    import inspect
+
+    source = inspect.getsource(SFTTrainer.train)
+    body = source.split('"""')[2]
+    assert "resume_from_checkpoint" in body

--- a/thinkrl/training/sft_trainer.py
+++ b/thinkrl/training/sft_trainer.py
@@ -35,6 +35,8 @@ except ImportError:
 
 logger = get_logger(__name__)
 
+TRAINER_STATE_FILE = "trainer_state.pt"
+
 
 @dataclass
 class SFTConfig:
@@ -180,6 +182,7 @@ class SFTTrainer:
 
         # State tracking
         self.global_step = 0
+        self.start_epoch = 0
         self.epoch = 0
         self.model_engine = None  # DeepSpeed engine
 
@@ -323,7 +326,10 @@ class SFTTrainer:
         Run training.
 
         Args:
-            resume_from_checkpoint: Path to checkpoint to resume from
+            resume_from_checkpoint: Directory written by save_model. Restores model weights,
+                optimizer state, scheduler state and the step counter, and resumes at the
+                saved epoch. Position within an epoch's dataloader is not restored, so the
+                first resumed epoch replays from its start.
 
         Returns:
             Training metrics
@@ -384,6 +390,9 @@ class SFTTrainer:
             )
             logger.info("Manual Optimizer & Scheduler Initialized")
 
+        if resume_from_checkpoint:
+            self._load_trainer_state(resume_from_checkpoint)
+
         # Refined Optimizer/Scheduler setup logic:
         # If DS init was skipped (no config), we rely on manual setup above.
         # Ideally, we should move Manual Setup to "else" block of DS check,
@@ -396,7 +405,7 @@ class SFTTrainer:
         if self.model_engine == self.model:  # Non-DS
             self.optimizer.zero_grad()
 
-        for epoch in range(self.args.num_train_epochs):
+        for epoch in range(self.start_epoch, self.args.num_train_epochs):
             self.epoch = epoch
             logger.info(f"Epoch {epoch + 1}/{self.args.num_train_epochs}")
 
@@ -562,7 +571,44 @@ class SFTTrainer:
         if self.tokenizer:
             self.tokenizer.save_pretrained(save_dir)
 
+        # Optimizer, scheduler and step counter live beside the weights so that
+        # resume_from_checkpoint can restore the run rather than only the model.
+        state = {
+            "global_step": self.global_step,
+            "epoch": self.epoch,
+            "optimizer": self.optimizer.state_dict() if self.optimizer is not None else None,
+            "scheduler": self.scheduler.state_dict() if self.scheduler is not None else None,
+        }
+        torch.save(state, os.path.join(save_dir, TRAINER_STATE_FILE))
+
         logger.info(f"Model saved to {save_dir}")
+
+    def _load_trainer_state(self, checkpoint_dir: str):
+        """Restore model weights, optimizer, scheduler and step counter from a checkpoint."""
+        if not os.path.isdir(checkpoint_dir):
+            raise FileNotFoundError(f"resume_from_checkpoint directory does not exist: {checkpoint_dir}")
+
+        # Weights first; from_pretrained on the existing class keeps the config intact.
+        self.model.load_state_dict(type(self.model).from_pretrained(checkpoint_dir).state_dict())
+        self.model.to(self.device)
+
+        state_path = os.path.join(checkpoint_dir, TRAINER_STATE_FILE)
+        if not os.path.isfile(state_path):
+            raise FileNotFoundError(
+                f"{checkpoint_dir} has model weights but no {TRAINER_STATE_FILE}, so the optimizer "
+                "and step counter cannot be restored. Resuming from it would silently restart "
+                "the schedule."
+            )
+
+        state = torch.load(state_path, map_location=self.device, weights_only=True)
+        if state.get("optimizer") is not None and self.optimizer is not None:
+            self.optimizer.load_state_dict(state["optimizer"])
+        if state.get("scheduler") is not None and self.scheduler is not None:
+            self.scheduler.load_state_dict(state["scheduler"])
+        self.global_step = state.get("global_step", 0)
+        self.start_epoch = state.get("epoch", 0)
+
+        logger.info(f"Resumed from {checkpoint_dir} at global_step={self.global_step}")
 
     def push_to_hub(self, repo_id: str, **kwargs):
         """


### PR DESCRIPTION
Closes #103.

`resume_from_checkpoint` appeared in the signature and the docstring and nowhere in the method body, so passing a checkpoint path silently restarted from step 0 with a fresh optimizer. On a multi-day job that is a day lost, and it is invisible from the outside because a fresh loss curve looks like a plausible loss curve.

Both halves were missing, so both are here. `save_model` now writes `trainer_state.pt` beside the weights, holding optimizer and scheduler state along with the step and epoch counters, and `train()` restores all of it and resumes at the saved epoch. A directory that does not exist, or one that has weights but no trainer state, raises rather than quietly starting over. `torch.load` runs with `weights_only=True`.

One deliberate limit, stated in the docstring rather than glossed: position within an epoch's dataloader is not restored, so the first resumed epoch replays from its start. Restoring the sampler position is a bigger change and I would rather it be its own.

Six tests on a one-layer GPT-2 built from config, so nothing is downloaded.
