### PR TITLE
Wire CheckpointManager into the GRPO, REINFORCE++ and STaR trainers

### DIFF
--- a/tests/test_training/test_rl_trainer_checkpointing.py
+++ b/tests/test_training/test_rl_trainer_checkpointing.py
@@ -1,0 +1,79 @@
+"""Regression test: the RL trainers must persist progress, not only the final model."""
+
+import inspect
+
+import torch
+import torch.nn as nn
+
+import thinkrl.training.grpo_trainer as grpo_trainer
+import thinkrl.training.reinforce_pp_trainer as reinforce_pp_trainer
+import thinkrl.training.star_trainer as star_trainer
+from thinkrl.utils.checkpoint import CheckpointManager, save_training_checkpoint
+
+
+class _TinyLM(nn.Module):
+    def __init__(self, vocab: int = 16, dim: int = 8):
+        super().__init__()
+        self.emb = nn.Embedding(vocab, dim)
+        self.head = nn.Linear(dim, vocab)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        return {"logits": self.head(self.emb(input_ids))}
+
+
+TRAINERS = (grpo_trainer.GRPOTrainer, reinforce_pp_trainer.ReinforcePPTrainer, star_trainer.STaRTrainer)
+
+
+def test_every_rl_trainer_accepts_a_checkpoint_directory():
+    """The regression: none of these took a checkpoint argument at all."""
+    for trainer in TRAINERS:
+        params = inspect.signature(trainer.train).parameters
+        assert "checkpoint_dir" in params, f"{trainer.__name__}.train has no checkpoint_dir"
+        assert "save_every" in params, f"{trainer.__name__}.train has no save_every"
+
+
+def test_every_rl_trainer_reaches_the_checkpoint_manager():
+    for module in (grpo_trainer, reinforce_pp_trainer, star_trainer):
+        source = inspect.getsource(module)
+        assert "CheckpointManager" in source, f"{module.__name__} never constructs a CheckpointManager"
+        assert "save_training_checkpoint" in source, f"{module.__name__} never saves"
+
+
+def test_helper_is_a_no_op_without_a_manager():
+    assert save_training_checkpoint(None, model=_TinyLM(), step=1) is None
+
+
+def test_helper_writes_a_loadable_checkpoint(tmp_path):
+    manager = CheckpointManager(tmp_path, max_checkpoints=5)
+    model = _TinyLM()
+
+    path = save_training_checkpoint(manager, model=model, epoch=0, step=7, metrics={"loss": 1.5})
+
+    assert path is not None and path.exists()
+    assert manager.checkpoints, "checkpoint was not registered with the manager"
+
+
+def test_helper_coerces_tensor_metrics(tmp_path):
+    """Trainers collect metrics as a mix of floats and 0-dim tensors."""
+    manager = CheckpointManager(tmp_path, max_checkpoints=5)
+
+    path = save_training_checkpoint(
+        manager,
+        model=_TinyLM(),
+        step=1,
+        metrics={"loss": torch.tensor(0.5), "reward": 2.0, "grad": torch.ones(3), "name": "ignored"},
+    )
+
+    assert path is not None
+    saved = manager.checkpoints[-1]["metrics"]
+    assert saved == {"loss": 0.5, "reward": 2.0}
+
+
+def test_rotation_keeps_max_checkpoints(tmp_path):
+    manager = CheckpointManager(tmp_path, max_checkpoints=2)
+    model = _TinyLM()
+
+    for step in range(4):
+        save_training_checkpoint(manager, model=model, step=step)
+
+    assert len(manager.checkpoints) <= 2

--- a/thinkrl/training/grpo_trainer.py
+++ b/thinkrl/training/grpo_trainer.py
@@ -9,6 +9,7 @@ from thinkrl.algorithms.grpo import GRPOAlgorithm, GRPOConfig
 from thinkrl.data.datasets import RLHFDataset
 from thinkrl.data.loaders import RLHFDataLoader
 from thinkrl.integration.vllm_client import VLLMClient
+from thinkrl.utils.checkpoint import CheckpointManager, save_training_checkpoint
 from thinkrl.utils.logging import get_logger
 
 
@@ -100,10 +101,30 @@ class GRPOTrainer:
             self.vllm_client = VLLMClient(group_port=vllm_group_port)
             self.vllm_client.init_weight_sync(self.device)
 
-    def train(self, steps: int = 1000, batch_size: int = 4, log_interval: int = 10):
+    def train(
+        self,
+        steps: int = 1000,
+        batch_size: int = 4,
+        log_interval: int = 10,
+        checkpoint_dir: str | None = None,
+        save_every: int = 0,
+        max_checkpoints: int = 5,
+    ):
         """
         Main training loop.
+
+        Args:
+            steps: Number of optimisation steps to run.
+            batch_size: Prompts per rollout.
+            log_interval: Steps between log lines.
+            checkpoint_dir: Where to write checkpoints. Nothing is written without it.
+            save_every: Save every N steps; 0 disables periodic saves. A final checkpoint is
+                still written whenever checkpoint_dir is set.
+            max_checkpoints: How many checkpoints to keep before the oldest rotates out.
         """
+        checkpointer = (
+            CheckpointManager(checkpoint_dir, max_checkpoints=max_checkpoints) if checkpoint_dir else None
+        )
         try:
             from tqdm import tqdm
         except ImportError:
@@ -135,8 +156,19 @@ class GRPOTrainer:
 
         step = 0
         epoch = 0
+        step_metrics: dict[str, Any] = {}
 
         progress_bar = tqdm(total=steps, desc="Training")
+
+        def checkpoint():
+            return save_training_checkpoint(
+                checkpointer,
+                model=self.algorithm.policy_model,
+                optimizer=getattr(self.algorithm, "optimizer", None),
+                epoch=epoch,
+                step=step,
+                metrics=step_metrics,
+            )
 
         while step < steps:
             for batch_prompts in dataloader:
@@ -215,9 +247,13 @@ class GRPOTrainer:
                 progress_bar.update(1)
                 step += 1
 
+                if save_every and step % save_every == 0:
+                    checkpoint()
+
             epoch += 1
 
         progress_bar.close()
+        checkpoint()
 
     def make_experience(self, batch_prompts: dict[str, Any]) -> dict[str, torch.Tensor]:
         """

--- a/thinkrl/training/reinforce_pp_trainer.py
+++ b/thinkrl/training/reinforce_pp_trainer.py
@@ -9,6 +9,7 @@ from thinkrl.algorithms.reinforce_pp import REINFORCEPPAlgorithm, REINFORCEPPCon
 from thinkrl.data.datasets import RLHFDataset
 from thinkrl.data.loaders import RLHFDataLoader
 from thinkrl.integration.vllm_client import VLLMClient
+from thinkrl.utils.checkpoint import CheckpointManager, save_training_checkpoint
 from thinkrl.utils.logging import get_logger
 
 
@@ -101,10 +102,30 @@ class ReinforcePPTrainer:
             # Verify compatibility before starting
             self.vllm_client.check_weights(self.algorithm.policy_model)
 
-    def train(self, steps: int = 1000, batch_size: int = 4, log_interval: int = 10):
+    def train(
+        self,
+        steps: int = 1000,
+        batch_size: int = 4,
+        log_interval: int = 10,
+        checkpoint_dir: str | None = None,
+        save_every: int = 0,
+        max_checkpoints: int = 5,
+    ):
         """
         Main training loop.
+
+        Args:
+            steps: Number of optimisation steps to run.
+            batch_size: Prompts per rollout.
+            log_interval: Steps between log lines.
+            checkpoint_dir: Where to write checkpoints. Nothing is written without it.
+            save_every: Save every N steps; 0 disables periodic saves. A final checkpoint is
+                still written whenever checkpoint_dir is set.
+            max_checkpoints: How many checkpoints to keep before the oldest rotates out.
         """
+        checkpointer = (
+            CheckpointManager(checkpoint_dir, max_checkpoints=max_checkpoints) if checkpoint_dir else None
+        )
         try:
             from tqdm import tqdm
         except ImportError:
@@ -137,8 +158,19 @@ class ReinforcePPTrainer:
 
         step = 0
         epoch = 0
+        step_metrics: dict[str, Any] = {}
 
         progress_bar = tqdm(total=steps, desc="Training")
+
+        def checkpoint():
+            return save_training_checkpoint(
+                checkpointer,
+                model=self.algorithm.policy_model,
+                optimizer=getattr(self.algorithm, "optimizer", None),
+                epoch=epoch,
+                step=step,
+                metrics=step_metrics,
+            )
 
         while step < steps:
             for batch_prompts in dataloader:
@@ -220,9 +252,13 @@ class ReinforcePPTrainer:
                 progress_bar.update(1)
                 step += 1
 
+                if save_every and step % save_every == 0:
+                    checkpoint()
+
             epoch += 1
 
         progress_bar.close()
+        checkpoint()
 
     def make_experience(self, batch_prompts: dict[str, Any]) -> dict[str, torch.Tensor]:
         """

--- a/thinkrl/training/star_trainer.py
+++ b/thinkrl/training/star_trainer.py
@@ -9,6 +9,7 @@ from transformers import GenerationConfig, PreTrainedTokenizer
 from thinkrl.algorithms.star import STaRAlgorithm, STaRConfig
 from thinkrl.data.datasets import RLHFDataset
 from thinkrl.data.loaders import RLHFDataLoader
+from thinkrl.utils.checkpoint import CheckpointManager, save_training_checkpoint
 from thinkrl.utils.logging import get_logger
 
 
@@ -61,11 +62,27 @@ class STaRTrainer:
         self.algorithm = STaRAlgorithm(policy_model=model, optimizer=optimizer, config=self.config, **algo_kwargs)
         self.algorithm.to(self.device)
 
-    def train(self, iterations: int | None = None):
+    def train(
+        self,
+        iterations: int | None = None,
+        checkpoint_dir: str | None = None,
+        save_every: int = 1,
+        max_checkpoints: int = 5,
+    ):
         """
         Main STaR loop.
+
+        Args:
+            iterations: Number of STaR iterations; defaults to config.max_iterations.
+            checkpoint_dir: Where to write checkpoints. Nothing is written without it.
+            save_every: Save every N iterations; 0 disables periodic saves. A final
+                checkpoint is still written whenever checkpoint_dir is set.
+            max_checkpoints: How many checkpoints to keep before the oldest rotates out.
         """
         iterations = iterations or self.config.max_iterations
+        checkpointer = (
+            CheckpointManager(checkpoint_dir, max_checkpoints=max_checkpoints) if checkpoint_dir else None
+        )
 
         logger.info(f"Starting STaR training for {iterations} iterations...")
 
@@ -85,6 +102,11 @@ class STaRTrainer:
 
             # 5. Fine-tune on collected data
             self.fine_tune(collected_data, iter_idx)
+
+            if save_every and (iter_idx + 1) % save_every == 0:
+                save_training_checkpoint(checkpointer, model=self.model, epoch=iter_idx, step=iter_idx + 1)
+
+        save_training_checkpoint(checkpointer, model=self.model, epoch=iterations - 1, step=iterations)
 
     def collect_successful_rationales(self, iter_idx: int):
         """

--- a/thinkrl/utils/checkpoint.py
+++ b/thinkrl/utils/checkpoint.py
@@ -765,10 +765,50 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
     return config
 
 
+def save_training_checkpoint(
+    manager: CheckpointManager | None,
+    model: nn.Module,
+    optimizer: Optimizer | None = None,
+    scheduler: _LRScheduler | None = None,
+    epoch: int | None = None,
+    step: int | None = None,
+    metrics: dict[str, Any] | None = None,
+) -> Path | None:
+    """Save a training checkpoint, tolerating a missing manager and tensor-valued metrics.
+
+    Trainers collect metrics as a mix of floats and zero-dimensional tensors, while
+    CheckpointManager stores them in JSON metadata, so they are coerced here rather than at
+    every call site.
+
+    Returns the checkpoint path, or None when no manager is configured.
+    """
+    if manager is None:
+        return None
+
+    scalar_metrics = {}
+    for key, value in (metrics or {}).items():
+        if isinstance(value, torch.Tensor):
+            if value.numel() != 1:
+                continue
+            value = value.item()
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            scalar_metrics[key] = float(value)
+
+    return manager.save_checkpoint(
+        model=model,
+        optimizer=optimizer,
+        scheduler=scheduler,
+        epoch=epoch,
+        step=step,
+        metrics=scalar_metrics,
+    )
+
+
 # Public API
 __all__ = [
     "CheckpointManager",
     "save_checkpoint",
+    "save_training_checkpoint",
     "load_checkpoint",
     "save_config",
     "load_config",


### PR DESCRIPTION
Closes #104.

`grpo_trainer.py`, `reinforce_pp_trainer.py` and `star_trainer.py` contained zero occurrences of `save` or `checkpoint`, so a run that died partway through left nothing behind. The only save in the GRPO path is the single final one in `cli/grpo.py`. Meanwhile `CheckpointManager` sat exported from `thinkrl/__init__.py` with its registry, rotation and best-checkpoint tracking, used by no trainer and no CLI.

Each `train()` now takes `checkpoint_dir`, `save_every` and `max_checkpoints`, saves every N steps and once at the end, and writes nothing at all when `checkpoint_dir` is unset, so existing callers are unaffected. `save_training_checkpoint` in `utils/checkpoint.py` absorbs the two things every call site would otherwise repeat: tolerating a missing manager, and coercing the mix of floats and zero-dimensional tensors the trainers collect into the scalar metrics the JSON metadata expects.

I left out saving on `KeyboardInterrupt`. It needs the whole loop body reindented into a `try`, which would bury a one-line change in a large diff, and periodic saving already bounds the loss to `save_every` steps. Happy to add it separately if you want it.

Six tests. Suite 744 passed against a 738 baseline.
