### PR TITLE
Populate the shipped config files and test that every one of them loads

### DIFF
--- a/configs/algos/dapo_config.yaml
+++ b/configs/algos/dapo_config.yaml
@@ -1,0 +1,30 @@
+# DAPO training configuration (nested schema loaded by ThinkRLConfig).
+# Hyperparameters match DAPOConfig defaults (thinkrl/algorithms/dapo.py).
+
+model:
+  name_or_path: HuggingFaceTB/SmolLM2-135M
+  dtype: bfloat16
+
+algorithm:
+  name: dapo
+  learning_rate: 1.0e-6
+  epsilon_low: 0.2          # clip-higher: asymmetric clipping, low side
+  epsilon_high: 0.28        # clip-higher: high side, encourages exploration
+  group_size: 16
+  beta: 0.0                 # KL disabled, per the paper
+  n_epochs: 1
+
+  # Dynamic sampling over-samples and discards groups whose rewards are all equal, since
+  # they carry no gradient. Not safe under DDP; leave off for distributed runs.
+  dynamic_sampling: false
+  min_batch_size: 256
+  max_sampling_attempts: 10
+
+  # Soft overlong punishment (Eq. 13): penalty ramps over the last cache_len tokens.
+  use_overlong_punishment: true
+  max_len: 16384
+  cache_len: 4096
+
+  clip_grad_norm: 1.0
+  advantage_eps: 1.0e-8
+  entropy_coeff: 0.0

--- a/configs/algos/grpo_config.yaml
+++ b/configs/algos/grpo_config.yaml
@@ -1,26 +1,17 @@
-# GRPO Algorithm Configuration
-# Matches GRPOConfig dataclass defaults (thinkrl/algorithms/grpo.py)
+# GRPO training configuration (nested schema loaded by ThinkRLConfig).
+# Algorithm hyperparameters match GRPOConfig defaults (thinkrl/algorithms/grpo.py).
 
-# Learning rate for policy optimizer
-learning_rate: 1.0e-6
+model:
+  name_or_path: HuggingFaceTB/SmolLM2-135M
+  dtype: bfloat16
 
-# Group size (G in the paper) — number of outputs sampled per prompt
-group_size: 64
-
-# PPO-style clipping epsilon
-clip_epsilon: 0.2
-
-# KL penalty coefficient (beta in Eq 19 of DeepSeekMath)
-beta: 0.04
-
-# Number of optimization epochs per rollout (mu in Algorithm 1)
-n_epochs: 1
-
-# Gradient clipping max norm
-clip_grad_norm: 1.0
-
-# Epsilon added to std to avoid division by zero in advantage normalization
-advantage_eps: 1.0e-8
-
-# Whether to use vLLM for high-throughput generation
-use_vllm: false
+algorithm:
+  name: grpo
+  learning_rate: 1.0e-6
+  group_size: 64          # G in the paper
+  clip_epsilon: 0.2       # PPO-style clipping
+  beta: 0.04              # KL penalty coefficient
+  n_epochs: 1             # optimization epochs per rollout (mu)
+  clip_grad_norm: 1.0
+  advantage_eps: 1.0e-8
+  use_vllm: false

--- a/configs/algos/ppo_config.yaml
+++ b/configs/algos/ppo_config.yaml
@@ -1,0 +1,21 @@
+# PPO training configuration (nested schema loaded by ThinkRLConfig).
+# Hyperparameters match PPOConfig defaults (thinkrl/algorithms/ppo.py).
+
+model:
+  name_or_path: HuggingFaceTB/SmolLM2-135M
+  dtype: bfloat16
+
+algorithm:
+  name: ppo
+  learning_rate: 3.0e-4
+  value_lr: null            # null reuses learning_rate for the critic
+  gamma: 0.99               # discount factor
+  gae_lambda: 0.95          # GAE lambda
+  policy_clip: 0.2          # PPO ratio clip
+  value_clip: 0.2           # value-function clip
+  value_coeff: 0.5
+  entropy_coeff: 0.01
+  n_epochs: 4               # optimization epochs per rollout
+  batch_size: 64            # minibatch size within an epoch
+  clip_grad_norm: 1.0
+  normalize_advantages: true

--- a/configs/algos/reinforce_config.yaml
+++ b/configs/algos/reinforce_config.yaml
@@ -1,0 +1,20 @@
+# REINFORCE training configuration (nested schema loaded by ThinkRLConfig).
+# Hyperparameters match REINFORCEConfig defaults (thinkrl/algorithms/reinforce.py).
+
+model:
+  name_or_path: HuggingFaceTB/SmolLM2-135M
+  dtype: bfloat16
+
+algorithm:
+  name: reinforce
+  learning_rate: 1.0e-5
+
+  # Baseline for variance reduction: none, moving_average or batch_mean.
+  baseline_type: moving_average
+  baseline_momentum: 0.99
+
+  entropy_coeff: 0.01
+  kl_coeff: 0.0
+  clip_grad_norm: 1.0
+  normalize_returns: true
+  gamma: 1.0                # 1.0 assigns the terminal reward to every response token

--- a/configs/algos/vapo_config.yaml
+++ b/configs/algos/vapo_config.yaml
@@ -1,0 +1,32 @@
+# VAPO training configuration (nested schema loaded by ThinkRLConfig).
+# Hyperparameters match VAPOConfig defaults (thinkrl/algorithms/vapo.py).
+
+model:
+  name_or_path: HuggingFaceTB/SmolLM2-135M
+  dtype: bfloat16
+
+algorithm:
+  name: vapo
+  learning_rate: 1.0e-6
+  value_lr: 2.0e-6          # the critic usually wants a higher rate than the policy
+
+  epsilon_low: 0.2          # clip-higher, low side
+  epsilon_high: 0.28        # clip-higher, high side
+
+  # Decoupled GAE: the critic learns from near-unbiased targets at lambda 1.0, while the
+  # policy uses a length-adaptive lambda = 1 - 1 / (alpha * response_length).
+  adaptive_gae_alpha: 0.05
+  gamma: 1.0                # 1.0 is standard for reasoning tasks
+  lambda_value: 1.0
+
+  # Auxiliary NLL loss on samples scoring above the threshold.
+  lm_loss_coeff: 0.1
+  positive_reward_threshold: 0.99
+
+  n_epochs: 2
+  batch_size: 64
+  clip_grad_norm: 1.0
+  value_clip: 0.2
+  value_coeff: 0.5
+  entropy_coeff: 0.01
+  normalize_advantages: true

--- a/configs/base_train_config.yaml
+++ b/configs/base_train_config.yaml
@@ -1,0 +1,37 @@
+# Base training configuration: every section ThinkRLConfig.from_dict understands, at its
+# dataclass default. Copy this file and override what you need; the algorithm section is
+# left for the per-algorithm files under configs/algos/.
+
+model:
+  name_or_path: meta-llama/Llama-3.1-8B
+  dtype: bfloat16
+  use_flash_attention: true
+  gradient_checkpointing: false
+  device_map: auto
+  # trust_remote_code executes code shipped with the model repository. Leave it off
+  # unless the model genuinely requires it and you trust the source.
+  trust_remote_code: false
+
+distributed:
+  strategy: zero2
+  micro_batch_size: 4
+  gradient_accumulation_steps: 4
+  offload_optimizer: false
+  offload_param: false
+  bf16: true
+  fp16: false
+
+data:
+  dataset: null            # required: HuggingFace dataset id or local path
+  max_length: 2048
+  max_prompt_length: 1024
+  max_response_length: 1024
+  batch_size: 4
+  prompt_column: prompt
+  response_column: response
+  apply_chat_template: true
+
+logging:
+  wandb_project: thinkrl
+  log_every_n_steps: 10
+  output_dir: ./outputs

--- a/configs/data_config.yaml
+++ b/configs/data_config.yaml
@@ -1,0 +1,21 @@
+# Data-only configuration. Merge into a training config, or load standalone to check that
+# the column names and length budgets match your dataset before starting a run.
+
+data:
+  dataset: null            # required: HuggingFace dataset id or local path
+  eval_dataset: null
+  max_length: 2048
+  max_prompt_length: 1024
+  max_response_length: 1024
+  batch_size: 4
+  buffer_size: 10000
+
+  # Column names as they appear in the dataset. prompt/response are used by the
+  # policy-gradient algorithms; chosen/rejected by the preference algorithms.
+  prompt_column: prompt
+  response_column: response
+  chosen_column: chosen
+  rejected_column: rejected
+
+  apply_chat_template: true
+  chat_template: null      # null uses the tokenizer's own template

--- a/configs/models/gpt_config.yaml
+++ b/configs/models/gpt_config.yaml
@@ -1,0 +1,10 @@
+# Small GPT-2 class model. Useful for smoke tests: it trains on a single consumer GPU and
+# on CPU, so the pipeline can be exercised before committing to a large run.
+
+model:
+  name_or_path: gpt2
+  dtype: float32
+  use_flash_attention: false      # not supported by the GPT-2 attention implementation
+  gradient_checkpointing: false
+  device_map: null
+  trust_remote_code: false

--- a/configs/models/llama_config.yaml
+++ b/configs/models/llama_config.yaml
@@ -1,0 +1,9 @@
+# Llama 3.x policy model.
+
+model:
+  name_or_path: meta-llama/Llama-3.1-8B
+  dtype: bfloat16
+  use_flash_attention: true
+  gradient_checkpointing: true    # 8B does not fit a single 80GB card without it
+  device_map: auto
+  trust_remote_code: false

--- a/configs/models/qwen_config.yaml
+++ b/configs/models/qwen_config.yaml
@@ -1,0 +1,9 @@
+# Qwen 2.5 policy model.
+
+model:
+  name_or_path: Qwen/Qwen2.5-7B
+  dtype: bfloat16
+  use_flash_attention: true
+  gradient_checkpointing: true
+  device_map: auto
+  trust_remote_code: false

--- a/configs/peft/lora_config.yaml
+++ b/configs/peft/lora_config.yaml
@@ -1,0 +1,12 @@
+# LoRA adapter settings. Combine with a model config to fine-tune adapters rather than
+# full weights.
+
+peft:
+  enabled: true
+  type: lora
+  r: 8
+  lora_alpha: 16
+  lora_dropout: 0.05
+  bias: none
+  target_modules: null      # null lets the adapter pick the attention projections
+  modules_to_save: null

--- a/tests/test_config/test_shipped_configs_load.py
+++ b/tests/test_config/test_shipped_configs_load.py
@@ -1,0 +1,68 @@
+"""Every non-empty YAML shipped under configs/ must load through the real loader.
+
+The directory previously held seventeen files, sixteen of them zero bytes, and the one with
+content used a flat schema the loader rejects, so no shipped config could be loaded at all.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from thinkrl.config.base import ThinkRLConfig
+
+
+CONFIG_ROOT = Path(__file__).resolve().parents[2] / "configs"
+YAML_FILES = sorted(CONFIG_ROOT.rglob("*.yaml"))
+
+# Files still empty because they would configure code that does not exist yet. Each entry
+# should be removed as the corresponding feature lands; the test below fails if one is
+# filled in and left listed here, so the list cannot rot.
+BLOCKED_ON_MISSING_FEATURES = {
+    "eval_config.yaml",                  # thinkrl/evaluation is four empty files
+    "reasoning/cot_config.yaml",         # thinkrl/reasoning/cot is empty
+    "reasoning/tot_config.yaml",         # thinkrl/reasoning/tot is empty
+    "models/multimodal_config.yaml",     # PAPO is not exported, no multimodal trainer
+    "models/moe_config.yaml",            # no MoE-specific handling in the model loader
+    "models/t5_config.yaml",             # the algorithms assume a decoder-only causal LM
+}
+
+POPULATED = [p for p in YAML_FILES if str(p.relative_to(CONFIG_ROOT)) not in BLOCKED_ON_MISSING_FEATURES]
+
+
+def _relative(path):
+    return str(path.relative_to(CONFIG_ROOT))
+
+
+def test_most_shipped_configs_are_populated():
+    assert POPULATED, f"no populated YAML files found under {CONFIG_ROOT}"
+    assert len(POPULATED) > len(BLOCKED_ON_MISSING_FEATURES)
+
+
+@pytest.mark.parametrize("path", POPULATED, ids=_relative)
+def test_shipped_config_is_not_a_zero_byte_file(path):
+    assert path.stat().st_size > 0, f"{path.name} is empty, so it cannot configure anything"
+
+
+@pytest.mark.parametrize("path", POPULATED, ids=_relative)
+def test_shipped_config_loads_through_the_real_loader(path):
+    assert ThinkRLConfig.from_yaml(path) is not None
+
+
+@pytest.mark.parametrize("path", POPULATED, ids=_relative)
+def test_shipped_config_uses_known_sections(path):
+    known = {"model", "algorithm", "distributed", "data", "logging", "peft"}
+    data = yaml.safe_load(path.read_text())
+
+    assert isinstance(data, dict), f"{path.name} did not parse into a mapping"
+    unknown = set(data) - known
+    assert not unknown, f"{path.name} has sections the loader ignores: {sorted(unknown)}"
+
+
+@pytest.mark.parametrize("name", sorted(BLOCKED_ON_MISSING_FEATURES))
+def test_blocked_list_does_not_go_stale(name):
+    """If a listed file gets content, it belongs in the tested set instead of on this list."""
+    path = CONFIG_ROOT / name
+    if not path.exists():
+        pytest.skip(f"{name} has been removed")
+    assert path.stat().st_size == 0, f"{name} now has content; remove it from BLOCKED_ON_MISSING_FEATURES"


### PR DESCRIPTION
Closes #106.

Sixteen of the seventeen YAMLs under `configs/` were zero bytes, so no documented `--config` invocation could work even once the loader accepts them.

This fills the ten that have real code behind them: `base_train`, `data`, the four algorithm configs, three model configs and the LoRA config, all on the nested schema and all matching their dataclass defaults so the two cannot drift.

Six are deliberately left empty because they would configure code that does not exist: `eval_config` (the evaluation package is empty), the two reasoning configs (CoT and ToT are empty), and the multimodal, MoE and T5 model configs. Shipping a config for a feature that is not there seemed worse than leaving the file. They are listed in the test with the reason for each, and the test fails if one gains content and stays listed, so the list cannot rot.

Stacked on the `grpo_config` schema fix, because the test asserts every populated file loads through the real loader and the flat `grpo_config.yaml` would otherwise fail it.
