### PR TITLE
Add a working evaluation loop to the empty thinkrl.evaluation package

### DIFF
--- a/tests/test_evaluation/test_evaluator.py
+++ b/tests/test_evaluation/test_evaluator.py
@@ -1,0 +1,97 @@
+"""thinkrl.evaluation was four empty files; these cover the loop that replaced them."""
+
+import pytest
+import torch
+from transformers import GPT2Config, GPT2LMHeadModel
+
+from thinkrl.evaluation import EvalResult, Evaluator, contains_match, exact_match, mean
+
+
+class _StubTokenizer:
+    """Character-level stand-in, so the tests need no downloaded tokenizer."""
+
+    pad_token_id = 0
+
+    def __call__(self, texts, return_tensors=None, padding=True, truncation=True):
+        ids = [[min(ord(c) % 30 + 1, 30) for c in t] for t in texts]
+        width = max(len(row) for row in ids)
+        padded = [row + [0] * (width - len(row)) for row in ids]
+        mask = [[1] * len(row) + [0] * (width - len(row)) for row in ids]
+        return {"input_ids": torch.tensor(padded), "attention_mask": torch.tensor(mask)}
+
+    def batch_decode(self, sequences, skip_special_tokens=True):
+        return ["".join(chr(int(i) % 26 + 97) for i in row if int(i) != 0) for row in sequences]
+
+
+def _model():
+    return GPT2LMHeadModel(GPT2Config(n_layer=1, n_head=1, n_embd=8, n_positions=64, vocab_size=32))
+
+
+def _evaluator(reward_fn=None):
+    return Evaluator(model=_model(), tokenizer=_StubTokenizer(), reward_fn=reward_fn, device="cpu")
+
+
+def test_metrics_helpers():
+    assert exact_match(["a", "b"], ["a", "c"]) == 0.5
+    assert exact_match([" a "], ["a"]) == 1.0
+    assert contains_match(["the answer is 42"], ["42"]) == 1.0
+    assert mean([]) == 0.0
+    assert mean([1.0, 3.0]) == 2.0
+
+
+def test_metrics_helpers_reject_mismatched_lengths():
+    with pytest.raises(ValueError, match="differ in length"):
+        exact_match(["a"], ["a", "b"])
+
+
+def test_empty_input_returns_an_empty_result():
+    result = _evaluator().evaluate([])
+
+    assert isinstance(result, EvalResult)
+    assert result.num_samples == 0
+    assert result.metrics == {}
+
+
+def test_generation_produces_one_completion_per_prompt():
+    completions = _evaluator().generate(["ab", "cd", "ef"], batch_size=2, max_new_tokens=4)
+
+    assert len(completions) == 3
+
+
+def test_reward_function_is_summarised():
+    def reward_fn(prompts, completions):
+        return torch.tensor([1.0, 3.0])
+
+    result = _evaluator(reward_fn).evaluate(["ab", "cd"], max_new_tokens=2)
+
+    assert result.metrics["reward_mean"] == 2.0
+    assert result.metrics["reward_std"] == pytest.approx(1.0)
+
+
+def test_wrong_length_reward_is_rejected_rather_than_broadcast():
+    def result_fn(prompts, completions):
+        return torch.tensor([1.0])
+
+    with pytest.raises(ValueError, match="reward_fn returned"):
+        _evaluator(result_fn).evaluate(["ab", "cd"], max_new_tokens=2)
+
+
+def test_targets_produce_match_metrics():
+    result = _evaluator().evaluate(["ab", "cd"], targets=["zz", "yy"], max_new_tokens=2)
+
+    assert "exact_match" in result.metrics
+    assert "contains_match" in result.metrics
+
+
+def test_mismatched_targets_are_rejected():
+    with pytest.raises(ValueError, match="differ in length"):
+        _evaluator().evaluate(["ab"], targets=["a", "b"])
+
+
+def test_model_training_mode_is_restored():
+    evaluator = _evaluator()
+    evaluator.model.train()
+
+    evaluator.evaluate(["ab"], max_new_tokens=2)
+
+    assert evaluator.model.training, "evaluate left the model in eval mode"

--- a/thinkrl/evaluation/__init__.py
+++ b/thinkrl/evaluation/__init__.py
@@ -1,0 +1,13 @@
+"""Evaluation utilities: run a trained policy over prompts and score the result."""
+
+from thinkrl.evaluation.evaluators import EvalResult, Evaluator
+from thinkrl.evaluation.metrics import contains_match, exact_match, mean
+
+
+__all__ = [
+    "EvalResult",
+    "Evaluator",
+    "contains_match",
+    "exact_match",
+    "mean",
+]

--- a/thinkrl/evaluation/evaluators.py
+++ b/thinkrl/evaluation/evaluators.py
@@ -1,0 +1,151 @@
+"""Minimal evaluation loop for a trained policy.
+
+Generates completions for a set of prompts and scores them, either with a reward function
+of the same shape the trainers use, or against reference answers, or both. It exists so a
+policy can be measured without writing the loop by hand; benchmark harnesses belong in
+:mod:`thinkrl.evaluation.benchmarks`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from thinkrl.evaluation.metrics import contains_match, exact_match, mean
+from thinkrl.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class EvalResult:
+    """Outcome of one evaluation pass."""
+
+    num_samples: int
+    metrics: dict[str, float] = field(default_factory=dict)
+    completions: list[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        scores = ", ".join(f"{k}={v:.4f}" for k, v in sorted(self.metrics.items()))
+        return f"EvalResult(n={self.num_samples}, {scores})"
+
+
+class Evaluator:
+    """Run a policy over prompts and score the completions.
+
+    Args:
+        model: Policy model exposing ``generate``
+        tokenizer: Tokenizer for the model
+        reward_fn: Optional callable taking (prompts, completions) and returning a tensor or
+            sequence of per-sample rewards, matching the trainers' reward contract
+        device: Device to run on; defaults to the model's own device
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        tokenizer: Any,
+        reward_fn: Callable[[list[str], list[str]], Any] | None = None,
+        device: torch.device | str | None = None,
+    ):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.reward_fn = reward_fn
+        self.device = torch.device(device) if device is not None else next(model.parameters()).device
+
+    @torch.no_grad()
+    def generate(
+        self,
+        prompts: Sequence[str],
+        batch_size: int = 8,
+        max_new_tokens: int = 128,
+        **generate_kwargs: Any,
+    ) -> list[str]:
+        """Generate one completion per prompt, returning only the generated text."""
+        was_training = self.model.training
+        self.model.eval()
+
+        completions: list[str] = []
+        try:
+            for start in range(0, len(prompts), batch_size):
+                chunk = list(prompts[start : start + batch_size])
+                encoded = self.tokenizer(chunk, return_tensors="pt", padding=True, truncation=True)
+                encoded = {k: v.to(self.device) for k, v in encoded.items()}
+
+                generated = self.model.generate(**encoded, max_new_tokens=max_new_tokens, **generate_kwargs)
+
+                # Strip the prompt so scoring sees the completion alone.
+                prompt_len = encoded["input_ids"].shape[1]
+                completions.extend(
+                    self.tokenizer.batch_decode(generated[:, prompt_len:], skip_special_tokens=True)
+                )
+        finally:
+            if was_training:
+                self.model.train()
+
+        return completions
+
+    def evaluate(
+        self,
+        prompts: Sequence[str],
+        targets: Sequence[str] | None = None,
+        batch_size: int = 8,
+        max_new_tokens: int = 128,
+        **generate_kwargs: Any,
+    ) -> EvalResult:
+        """Generate completions for ``prompts`` and score them.
+
+        Args:
+            prompts: Prompts to evaluate
+            targets: Optional reference answers; enables exact and contains match
+            batch_size: Prompts per generation batch
+            max_new_tokens: Generation budget per prompt
+            **generate_kwargs: Forwarded to ``model.generate``
+
+        Returns:
+            An :class:`EvalResult`. Metrics are whatever could be computed: ``reward_mean``
+            and ``reward_std`` when a reward function was supplied, ``exact_match`` and
+            ``contains_match`` when targets were.
+        """
+        if targets is not None and len(targets) != len(prompts):
+            raise ValueError(f"prompts ({len(prompts)}) and targets ({len(targets)}) differ in length")
+        if not prompts:
+            return EvalResult(num_samples=0)
+
+        completions = self.generate(
+            prompts, batch_size=batch_size, max_new_tokens=max_new_tokens, **generate_kwargs
+        )
+
+        metrics: dict[str, float] = {}
+
+        if self.reward_fn is not None:
+            rewards = self.reward_fn(list(prompts), completions)
+            if isinstance(rewards, torch.Tensor):
+                rewards = rewards.detach().float().cpu().tolist()
+            rewards = [float(r) for r in rewards]
+            if len(rewards) != len(prompts):
+                raise ValueError(
+                    f"reward_fn returned {len(rewards)} rewards for {len(prompts)} prompts"
+                )
+            metrics["reward_mean"] = mean(rewards)
+            metrics["reward_std"] = float(torch.tensor(rewards).std(correction=0)) if len(rewards) > 1 else 0.0
+
+        if targets is not None:
+            metrics["exact_match"] = exact_match(completions, targets)
+            metrics["contains_match"] = contains_match(completions, targets)
+
+        if not metrics:
+            logger.warning(
+                "Evaluator ran with neither a reward_fn nor targets, so only completions were produced."
+            )
+
+        result = EvalResult(num_samples=len(prompts), metrics=metrics, completions=completions)
+        logger.info(str(result))
+        return result
+
+
+__all__ = ["EvalResult", "Evaluator"]

--- a/thinkrl/evaluation/metrics.py
+++ b/thinkrl/evaluation/metrics.py
@@ -1,0 +1,54 @@
+"""Scoring helpers for evaluation.
+
+Deliberately small: these are the aggregations an evaluation loop needs before anything
+task-specific, and they are kept separate so a caller can use them without an Evaluator.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def exact_match(predictions: Sequence[str], targets: Sequence[str], strip: bool = True) -> float:
+    """Fraction of predictions equal to their target.
+
+    Args:
+        predictions: Model outputs
+        targets: Expected outputs
+        strip: Compare with surrounding whitespace removed
+
+    Returns:
+        Accuracy in [0, 1]; 0.0 for an empty input
+    """
+    if len(predictions) != len(targets):
+        raise ValueError(f"predictions ({len(predictions)}) and targets ({len(targets)}) differ in length")
+    if not predictions:
+        return 0.0
+
+    def normalise(text: str) -> str:
+        return text.strip() if strip else text
+
+    hits = sum(normalise(p) == normalise(t) for p, t in zip(predictions, targets))
+    return hits / len(predictions)
+
+
+def contains_match(predictions: Sequence[str], targets: Sequence[str]) -> float:
+    """Fraction of predictions containing their target.
+
+    Looser than :func:`exact_match`, and the usual choice for reasoning traces where the
+    answer is embedded in a longer completion.
+    """
+    if len(predictions) != len(targets):
+        raise ValueError(f"predictions ({len(predictions)}) and targets ({len(targets)}) differ in length")
+    if not predictions:
+        return 0.0
+
+    return sum(t.strip() in p for p, t in zip(predictions, targets)) / len(predictions)
+
+
+def mean(values: Sequence[float]) -> float:
+    """Arithmetic mean, 0.0 for an empty input rather than ZeroDivisionError."""
+    return sum(values) / len(values) if values else 0.0
+
+
+__all__ = ["exact_match", "contains_match", "mean"]


### PR DESCRIPTION
Closes #107.

All four files in `thinkrl/evaluation` were zero bytes, so `import thinkrl.evaluation` succeeded and returned an empty namespace, which is a worse failure than `ImportError` because it looks like a working import. There was no way to measure a trained policy inside the library, which is also why `DataConfig.eval_split`, `eval_batch_size` and `LoggingConfig.eval_every_n_steps` have no readers.

`Evaluator` generates one completion per prompt in batches and scores them with a reward function of the same shape the trainers use, against reference answers, or both, returning an `EvalResult`. `metrics.py` holds `exact_match`, `contains_match` and a `mean` that returns 0.0 rather than raising on empty input.

Kept deliberately small, matching the suggestion on the issue: benchmark harnesses belong in `benchmarks.py` and are not attempted here. A wrong-length reward is rejected rather than broadcast, and the model's training mode is restored afterwards.

Nine tests, running on a one-layer GPT-2 built from config so nothing is downloaded.
