### PR TITLE
Stop the README presenting the unimplemented CoT trainer as runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ Unlike standard RLHF libraries, ThinkRL focuses on **Reasoning (System 2)** capa
 
 ### Token-in-Token-out Agents
 We treat every model as an agent that consumes tokens (observations/prompts) and produces tokens (thoughts/actions). This unified interface supports:
-- **Chain-of-Thought (CoT)**: Linear reasoning traces.
-- **Tree-of-Thought (ToT)**: Branching exploration.
-- **Multimodal Inputs**: Visual and textual context (via PAPO).
+- **Chain-of-Thought (CoT)**: Linear reasoning traces. *(planned, not implemented)*
+- **Tree-of-Thought (ToT)**: Branching exploration. *(planned, not implemented)*
+- **Multimodal Inputs**: Visual and textual context via PAPO. *(the algorithm is
+  implemented but not yet exported; see #75)*
 
 ---
 
@@ -164,31 +165,34 @@ pip install -e .[all]
 
 ### Typical Workflow
 
-**1. Supervised Fine-Tuning (SFT) / CoT**
+**1. Supervised Fine-Tuning (SFT)**
 
 ```python
-from thinkrl.training import CoTTrainer, CoTConfig
+from thinkrl.training import SFTConfig, SFTTrainer
 
-config = CoTConfig(
-    model_name_or_path="Qwen/Qwen2.5-7B",
-    reasoning_type="cot",
-    max_reasoning_steps=10
-)
+config = SFTConfig(output_dir="./sft_output", num_train_epochs=1)
 
-trainer = CoTTrainer(config)
+trainer = SFTTrainer(model=model, args=config, train_dataset=dataset, tokenizer=tokenizer)
 trainer.train()
 ```
 
-**2. RLHF with PPO/GRPO/VAPO**
+> **CoT / ToT trainers are not implemented yet.** `thinkrl.training.CoTTrainer` and
+> `CoTConfig` do not exist and importing them raises `ImportError`; the modules under
+> `thinkrl/reasoning/` are empty placeholders. See the In Development section below.
+
+**2. RLHF with GRPO**
 
 ```bash
-# Launch generic RL training via CLI
-python -m thinkrl.cli.train_rl \
-    --algo vapo \
-    --model_name_or_path meta-llama/Llama-3-8b \
-    --reward_model_path ./rm_checkpoint \
-    --use_vllm True
+# GRPO is the training loop that is implemented end to end today.
+thinkrl grpo \
+    --model HuggingFaceTB/SmolLM2-135M \
+    --dataset gsm8k \
+    --steps 1000
 ```
+
+> The generic `--algo` entry point does not exist yet: `thinkrl.cli.train_rl` is not a
+> module, and the `train`, `sft`, `dpo` and `ppo` subcommands are stubs. GRPO and STaR are
+> the two implemented CLIs.
 
 ---
 

--- a/tests/test_readme_claims.py
+++ b/tests/test_readme_claims.py
@@ -1,0 +1,38 @@
+"""The README must not present unimplemented APIs as runnable.
+
+It documented `from thinkrl.training import CoTTrainer, CoTConfig`, which raises
+ImportError, and a `thinkrl.cli.train_rl` entry point that is not a module.
+"""
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+TEXT = README.read_text()
+
+# Imports that appear in fenced python blocks and are expected to work.
+PYTHON_IMPORTS = re.findall(r"^from (thinkrl[\w.]*) import ([^\n]+)$", TEXT, flags=re.MULTILINE)
+
+
+def test_readme_exists_and_mentions_thinkrl():
+    assert "thinkrl" in TEXT.lower()
+
+
+@pytest.mark.parametrize(("module", "names"), PYTHON_IMPORTS, ids=lambda v: str(v)[:40])
+def test_every_documented_import_resolves(module, names):
+    imported = importlib.import_module(module)
+    for name in (n.strip() for n in names.split(",")):
+        assert hasattr(imported, name), f"README documents {module}.{name}, which does not exist"
+
+
+def test_unimplemented_trainers_are_marked_as_such():
+    assert "CoT / ToT trainers are not implemented yet" in TEXT
+
+
+def test_no_bare_cot_trainer_import_is_presented_as_working():
+    working_imports = {f"{module}.{name.strip()}" for module, names in PYTHON_IMPORTS for name in names.split(",")}
+    assert "thinkrl.training.CoTTrainer" not in working_imports


### PR DESCRIPTION
Closes #108.

The quickstart showed `from thinkrl.training import CoTTrainer, CoTConfig` as step one, which raises `ImportError`: every file under `thinkrl/reasoning/` and both reasoning trainers are zero bytes. It also showed `python -m thinkrl.cli.train_rl --algo vapo`, and that module does not exist either. For a library that describes itself as reasoning-centric, that is the first thing a new reader tries.

The quickstart now shows SFT and GRPO, which are the two paths that work end to end, each followed by an explicit note on what is missing and why. The reasoning-paradigm bullets are marked as planned, and the PAPO bullet points at the export gap in #75.

The added test walks every `from thinkrl... import ...` in the README and asserts each name resolves, so the next documented API that does not exist fails in CI rather than in someone's terminal. It fails on `main`.

This is the documentation half only. Implementing CoT and ToT is the larger piece and belongs in its own change.
