### PR TITLE
Fill the basic examples and repoint the README dead script links

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,19 @@ python -m thinkrl.cli.train_rl \
 <a id="training-guides"></a>
 ## 🎓 Training Guides
 
-See `examples/` for detailed scripts:
-- [SFT & CoT Training](./examples/scripts/train_sft_cot.sh)
-- [DPO / Online DPO](./examples/scripts/train_dpo.sh)
-- [PRM Training](./examples/scripts/train_prm.sh)
-- [Multimodal PAPO](./examples/scripts/train_papo.sh)
+See `examples/` for runnable scripts. These four run on CPU with a small model:
+- [Minimal GRPO run](./examples/basic/train_simple.py)
+- [Inference from a model or checkpoint](./examples/basic/inference.py)
+- [Evaluating a policy](./examples/basic/evaluate_model.py)
+- [Supervised fine-tuning](./examples/sft/train_sft_small.py)
+
+And these need a GPU:
+- [GRPO on a reasoning dataset](./examples/reasoning/train_grpo.py)
+- [REINFORCE++](./examples/reasoning/train_reinforce_pp.py)
+- [STaR](./examples/reasoning/train_star.py)
+- [Custom reward functions](./examples/example_universal_reward.py)
+
+DPO, PRM and multimodal PAPO examples are not written yet.
 
 ---
 
@@ -253,7 +261,7 @@ python -m thinkrl.cli.merge_lora \
 
 ## 🤝 Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md).
+We welcome contributions! Please see [CONTRIBUTION.md](CONTRIBUTION.md).
 
 ## 📄 Citation
 

--- a/examples/basic/evaluate_model.py
+++ b/examples/basic/evaluate_model.py
@@ -1,0 +1,56 @@
+"""
+ThinkRL Evaluation Example
+==========================
+
+Score a model, or a checkpoint produced by one of the trainers, with the Evaluator.
+
+Usage:
+    python examples/basic/evaluate_model.py --model facebook/opt-125m
+
+Runs on CPU with the default model.
+"""
+
+import argparse
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from thinkrl.evaluation import Evaluator
+from thinkrl.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+PROMPTS = ["What is 2 + 2?", "Name a primary colour:", "Count to three:"]
+TARGETS = ["4", "red", "1 2 3"]
+
+
+def length_reward(prompts: list[str], completions: list[str]) -> torch.Tensor:
+    """Same brevity reward as the training example, so the two are comparable."""
+    target = 40
+    return torch.tensor([max(0.0, 1.0 - abs(len(c) - target) / target) for c in completions])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="facebook/opt-125m", help="Model id or checkpoint directory")
+    parser.add_argument("--max-new-tokens", type=int, default=32)
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "left"
+
+    model = AutoModelForCausalLM.from_pretrained(args.model, dtype=torch.float32)
+
+    evaluator = Evaluator(model=model, tokenizer=tokenizer, reward_fn=length_reward)
+    result = evaluator.evaluate(PROMPTS, targets=TARGETS, max_new_tokens=args.max_new_tokens)
+
+    print(result)
+    for prompt, completion in zip(PROMPTS, result.completions):
+        print(f"\n> {prompt}\n{completion.strip()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/basic/inference.py
+++ b/examples/basic/inference.py
@@ -1,0 +1,61 @@
+"""
+ThinkRL Inference Example
+=========================
+
+Load a model, or a checkpoint produced by one of the trainers, and generate completions.
+
+Usage:
+    python examples/basic/inference.py --model facebook/opt-125m --prompt "What is 2 + 2?"
+    python examples/basic/inference.py --model ./outputs/checkpoint_epoch0_step100
+
+Runs on CPU with the default model.
+"""
+
+import argparse
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from thinkrl.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="facebook/opt-125m", help="Model id or checkpoint directory")
+    parser.add_argument("--tokenizer", default=None, help="Defaults to --model")
+    parser.add_argument("--prompt", action="append", help="Repeatable; a default set is used if omitted")
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    parser.add_argument("--temperature", type=float, default=0.7)
+    args = parser.parse_args()
+
+    prompts = args.prompt or ["What is 2 + 2?", "Name a colour:"]
+
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer or args.model)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    # Decoder-only generation needs left padding, or short prompts are padded on the side
+    # the model continues from.
+    tokenizer.padding_side = "left"
+
+    model = AutoModelForCausalLM.from_pretrained(args.model, dtype=torch.float32)
+    model.eval()
+
+    encoded = tokenizer(prompts, return_tensors="pt", padding=True)
+    generated = model.generate(
+        **encoded,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=args.temperature > 0,
+        temperature=args.temperature,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+
+    completions = tokenizer.batch_decode(generated[:, encoded["input_ids"].shape[1] :], skip_special_tokens=True)
+    for prompt, completion in zip(prompts, completions):
+        print(f"\n> {prompt}\n{completion.strip()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/basic/train_simple.py
+++ b/examples/basic/train_simple.py
@@ -1,0 +1,88 @@
+"""
+ThinkRL Minimal GRPO Example
+============================
+
+The smallest end-to-end GRPO run: a small model, a toy prompt set, and a reward function
+that scores completions on a property you can check without a reward model. Meant to prove
+the pipeline works on your machine before committing to a real run.
+
+Usage:
+    python examples/basic/train_simple.py --steps 20
+
+Runs on CPU with the default model (~250 MB), so it needs no GPU.
+"""
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from thinkrl.algorithms.grpo import GRPOConfig
+from thinkrl.data.datasets import RLHFDataset
+from thinkrl.training.grpo_trainer import GRPOTrainer
+from thinkrl.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+PROMPTS = [
+    "Count from one to five:",
+    "Name three primary colours:",
+    "What is two plus two?",
+    "List two planets:",
+]
+
+
+def length_reward(prompts: list[str], completions: list[str], **kwargs) -> torch.Tensor:
+    """Reward brevity, scaled into [0, 1].
+
+    A stand-in for a real reward model: it is cheap, deterministic and moves in a direction
+    you can see in the logs, which is what a smoke test needs.
+    """
+    target = 40
+    scores = [max(0.0, 1.0 - abs(len(c) - target) / target) for c in completions]
+    return torch.tensor(scores, dtype=torch.float32)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="facebook/opt-125m")
+    parser.add_argument("--steps", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--group-size", type=int, default=4)
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    # float32 explicitly: many checkpoints (opt-125m among them) declare float16 in their
+    # config, and AdamW with eps=1e-8 cannot train fp16 weights, eps underflows to zero.
+    model = AutoModelForCausalLM.from_pretrained(args.model, dtype=torch.float32)
+    ref_model = AutoModelForCausalLM.from_pretrained(args.model, dtype=torch.float32)
+
+    # RLHFDataset loads from a path, so the toy prompts are written out first.
+    prompt_file = Path(tempfile.mkdtemp()) / "prompts.jsonl"
+    prompt_file.write_text("\n".join(json.dumps({"prompt": p}) for p in PROMPTS))
+
+    dataset = RLHFDataset(dataset_name_or_path=str(prompt_file), tokenizer=tokenizer)
+
+    trainer = GRPOTrainer(
+        model=model,
+        ref_model=ref_model,
+        tokenizer=tokenizer,
+        dataset=dataset,
+        reward_fn=length_reward,
+        config=GRPOConfig(group_size=args.group_size),
+    )
+
+    logger.info(f"Training {args.model} for {args.steps} steps on {len(PROMPTS)} prompts")
+    trainer.train(steps=args.steps, batch_size=args.batch_size)
+    logger.info("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_evaluation/test_evaluator.py
+++ b/tests/test_evaluation/test_evaluator.py
@@ -1,0 +1,97 @@
+"""thinkrl.evaluation was four empty files; these cover the loop that replaced them."""
+
+import pytest
+import torch
+from transformers import GPT2Config, GPT2LMHeadModel
+
+from thinkrl.evaluation import EvalResult, Evaluator, contains_match, exact_match, mean
+
+
+class _StubTokenizer:
+    """Character-level stand-in, so the tests need no downloaded tokenizer."""
+
+    pad_token_id = 0
+
+    def __call__(self, texts, return_tensors=None, padding=True, truncation=True):
+        ids = [[min(ord(c) % 30 + 1, 30) for c in t] for t in texts]
+        width = max(len(row) for row in ids)
+        padded = [row + [0] * (width - len(row)) for row in ids]
+        mask = [[1] * len(row) + [0] * (width - len(row)) for row in ids]
+        return {"input_ids": torch.tensor(padded), "attention_mask": torch.tensor(mask)}
+
+    def batch_decode(self, sequences, skip_special_tokens=True):
+        return ["".join(chr(int(i) % 26 + 97) for i in row if int(i) != 0) for row in sequences]
+
+
+def _model():
+    return GPT2LMHeadModel(GPT2Config(n_layer=1, n_head=1, n_embd=8, n_positions=64, vocab_size=32))
+
+
+def _evaluator(reward_fn=None):
+    return Evaluator(model=_model(), tokenizer=_StubTokenizer(), reward_fn=reward_fn, device="cpu")
+
+
+def test_metrics_helpers():
+    assert exact_match(["a", "b"], ["a", "c"]) == 0.5
+    assert exact_match([" a "], ["a"]) == 1.0
+    assert contains_match(["the answer is 42"], ["42"]) == 1.0
+    assert mean([]) == 0.0
+    assert mean([1.0, 3.0]) == 2.0
+
+
+def test_metrics_helpers_reject_mismatched_lengths():
+    with pytest.raises(ValueError, match="differ in length"):
+        exact_match(["a"], ["a", "b"])
+
+
+def test_empty_input_returns_an_empty_result():
+    result = _evaluator().evaluate([])
+
+    assert isinstance(result, EvalResult)
+    assert result.num_samples == 0
+    assert result.metrics == {}
+
+
+def test_generation_produces_one_completion_per_prompt():
+    completions = _evaluator().generate(["ab", "cd", "ef"], batch_size=2, max_new_tokens=4)
+
+    assert len(completions) == 3
+
+
+def test_reward_function_is_summarised():
+    def reward_fn(prompts, completions):
+        return torch.tensor([1.0, 3.0])
+
+    result = _evaluator(reward_fn).evaluate(["ab", "cd"], max_new_tokens=2)
+
+    assert result.metrics["reward_mean"] == 2.0
+    assert result.metrics["reward_std"] == pytest.approx(1.0)
+
+
+def test_wrong_length_reward_is_rejected_rather_than_broadcast():
+    def result_fn(prompts, completions):
+        return torch.tensor([1.0])
+
+    with pytest.raises(ValueError, match="reward_fn returned"):
+        _evaluator(result_fn).evaluate(["ab", "cd"], max_new_tokens=2)
+
+
+def test_targets_produce_match_metrics():
+    result = _evaluator().evaluate(["ab", "cd"], targets=["zz", "yy"], max_new_tokens=2)
+
+    assert "exact_match" in result.metrics
+    assert "contains_match" in result.metrics
+
+
+def test_mismatched_targets_are_rejected():
+    with pytest.raises(ValueError, match="differ in length"):
+        _evaluator().evaluate(["ab"], targets=["a", "b"])
+
+
+def test_model_training_mode_is_restored():
+    evaluator = _evaluator()
+    evaluator.model.train()
+
+    evaluator.evaluate(["ab"], max_new_tokens=2)
+
+    assert evaluator.model.training, "evaluate left the model in eval mode"

--- a/tests/test_readme_links.py
+++ b/tests/test_readme_links.py
@@ -1,0 +1,40 @@
+"""Relative links in the README must point at files that exist.
+
+The training-guides section linked four scripts under examples/scripts/, a directory that
+has never existed in the repository.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+
+# Markdown links whose target is a relative path, ignoring URLs and in-page anchors.
+RELATIVE_LINKS = sorted(
+    {
+        target
+        for target in re.findall(r"\]\(([^)]+)\)", README.read_text())
+        if not target.startswith(("http://", "https://", "#", "mailto:"))
+    }
+)
+
+
+def test_readme_has_relative_links_to_check():
+    assert RELATIVE_LINKS
+
+
+@pytest.mark.parametrize("target", RELATIVE_LINKS)
+def test_relative_link_resolves(target):
+    path = (ROOT / target.split("#")[0]).resolve()
+    assert path.exists(), f"README links {target}, which does not exist"
+
+
+def test_linked_examples_are_not_empty():
+    for target in RELATIVE_LINKS:
+        path = ROOT / target.split("#")[0]
+        if path.suffix == ".py" and path.exists():
+            assert path.stat().st_size > 0, f"README links {target}, which is an empty file"

--- a/thinkrl/evaluation/__init__.py
+++ b/thinkrl/evaluation/__init__.py
@@ -1,0 +1,13 @@
+"""Evaluation utilities: run a trained policy over prompts and score the result."""
+
+from thinkrl.evaluation.evaluators import EvalResult, Evaluator
+from thinkrl.evaluation.metrics import contains_match, exact_match, mean
+
+
+__all__ = [
+    "EvalResult",
+    "Evaluator",
+    "contains_match",
+    "exact_match",
+    "mean",
+]

--- a/thinkrl/evaluation/evaluators.py
+++ b/thinkrl/evaluation/evaluators.py
@@ -1,0 +1,151 @@
+"""Minimal evaluation loop for a trained policy.
+
+Generates completions for a set of prompts and scores them, either with a reward function
+of the same shape the trainers use, or against reference answers, or both. It exists so a
+policy can be measured without writing the loop by hand; benchmark harnesses belong in
+:mod:`thinkrl.evaluation.benchmarks`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from thinkrl.evaluation.metrics import contains_match, exact_match, mean
+from thinkrl.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class EvalResult:
+    """Outcome of one evaluation pass."""
+
+    num_samples: int
+    metrics: dict[str, float] = field(default_factory=dict)
+    completions: list[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        scores = ", ".join(f"{k}={v:.4f}" for k, v in sorted(self.metrics.items()))
+        return f"EvalResult(n={self.num_samples}, {scores})"
+
+
+class Evaluator:
+    """Run a policy over prompts and score the completions.
+
+    Args:
+        model: Policy model exposing ``generate``
+        tokenizer: Tokenizer for the model
+        reward_fn: Optional callable taking (prompts, completions) and returning a tensor or
+            sequence of per-sample rewards, matching the trainers' reward contract
+        device: Device to run on; defaults to the model's own device
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        tokenizer: Any,
+        reward_fn: Callable[[list[str], list[str]], Any] | None = None,
+        device: torch.device | str | None = None,
+    ):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.reward_fn = reward_fn
+        self.device = torch.device(device) if device is not None else next(model.parameters()).device
+
+    @torch.no_grad()
+    def generate(
+        self,
+        prompts: Sequence[str],
+        batch_size: int = 8,
+        max_new_tokens: int = 128,
+        **generate_kwargs: Any,
+    ) -> list[str]:
+        """Generate one completion per prompt, returning only the generated text."""
+        was_training = self.model.training
+        self.model.eval()
+
+        completions: list[str] = []
+        try:
+            for start in range(0, len(prompts), batch_size):
+                chunk = list(prompts[start : start + batch_size])
+                encoded = self.tokenizer(chunk, return_tensors="pt", padding=True, truncation=True)
+                encoded = {k: v.to(self.device) for k, v in encoded.items()}
+
+                generated = self.model.generate(**encoded, max_new_tokens=max_new_tokens, **generate_kwargs)
+
+                # Strip the prompt so scoring sees the completion alone.
+                prompt_len = encoded["input_ids"].shape[1]
+                completions.extend(
+                    self.tokenizer.batch_decode(generated[:, prompt_len:], skip_special_tokens=True)
+                )
+        finally:
+            if was_training:
+                self.model.train()
+
+        return completions
+
+    def evaluate(
+        self,
+        prompts: Sequence[str],
+        targets: Sequence[str] | None = None,
+        batch_size: int = 8,
+        max_new_tokens: int = 128,
+        **generate_kwargs: Any,
+    ) -> EvalResult:
+        """Generate completions for ``prompts`` and score them.
+
+        Args:
+            prompts: Prompts to evaluate
+            targets: Optional reference answers; enables exact and contains match
+            batch_size: Prompts per generation batch
+            max_new_tokens: Generation budget per prompt
+            **generate_kwargs: Forwarded to ``model.generate``
+
+        Returns:
+            An :class:`EvalResult`. Metrics are whatever could be computed: ``reward_mean``
+            and ``reward_std`` when a reward function was supplied, ``exact_match`` and
+            ``contains_match`` when targets were.
+        """
+        if targets is not None and len(targets) != len(prompts):
+            raise ValueError(f"prompts ({len(prompts)}) and targets ({len(targets)}) differ in length")
+        if not prompts:
+            return EvalResult(num_samples=0)
+
+        completions = self.generate(
+            prompts, batch_size=batch_size, max_new_tokens=max_new_tokens, **generate_kwargs
+        )
+
+        metrics: dict[str, float] = {}
+
+        if self.reward_fn is not None:
+            rewards = self.reward_fn(list(prompts), completions)
+            if isinstance(rewards, torch.Tensor):
+                rewards = rewards.detach().float().cpu().tolist()
+            rewards = [float(r) for r in rewards]
+            if len(rewards) != len(prompts):
+                raise ValueError(
+                    f"reward_fn returned {len(rewards)} rewards for {len(prompts)} prompts"
+                )
+            metrics["reward_mean"] = mean(rewards)
+            metrics["reward_std"] = float(torch.tensor(rewards).std(correction=0)) if len(rewards) > 1 else 0.0
+
+        if targets is not None:
+            metrics["exact_match"] = exact_match(completions, targets)
+            metrics["contains_match"] = contains_match(completions, targets)
+
+        if not metrics:
+            logger.warning(
+                "Evaluator ran with neither a reward_fn nor targets, so only completions were produced."
+            )
+
+        result = EvalResult(num_samples=len(prompts), metrics=metrics, completions=completions)
+        logger.info(str(result))
+        return result
+
+
+__all__ = ["EvalResult", "Evaluator"]

--- a/thinkrl/evaluation/metrics.py
+++ b/thinkrl/evaluation/metrics.py
@@ -1,0 +1,54 @@
+"""Scoring helpers for evaluation.
+
+Deliberately small: these are the aggregations an evaluation loop needs before anything
+task-specific, and they are kept separate so a caller can use them without an Evaluator.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def exact_match(predictions: Sequence[str], targets: Sequence[str], strip: bool = True) -> float:
+    """Fraction of predictions equal to their target.
+
+    Args:
+        predictions: Model outputs
+        targets: Expected outputs
+        strip: Compare with surrounding whitespace removed
+
+    Returns:
+        Accuracy in [0, 1]; 0.0 for an empty input
+    """
+    if len(predictions) != len(targets):
+        raise ValueError(f"predictions ({len(predictions)}) and targets ({len(targets)}) differ in length")
+    if not predictions:
+        return 0.0
+
+    def normalise(text: str) -> str:
+        return text.strip() if strip else text
+
+    hits = sum(normalise(p) == normalise(t) for p, t in zip(predictions, targets))
+    return hits / len(predictions)
+
+
+def contains_match(predictions: Sequence[str], targets: Sequence[str]) -> float:
+    """Fraction of predictions containing their target.
+
+    Looser than :func:`exact_match`, and the usual choice for reasoning traces where the
+    answer is embedded in a longer completion.
+    """
+    if len(predictions) != len(targets):
+        raise ValueError(f"predictions ({len(predictions)}) and targets ({len(targets)}) differ in length")
+    if not predictions:
+        return 0.0
+
+    return sum(t.strip() in p for p, t in zip(predictions, targets)) / len(predictions)
+
+
+def mean(values: Sequence[float]) -> float:
+    """Arithmetic mean, 0.0 for an empty input rather than ZeroDivisionError."""
+    return sum(values) / len(values) if values else 0.0
+
+
+__all__ = ["exact_match", "contains_match", "mean"]


### PR DESCRIPTION
Closes #111.

Twelve of seventeen files under `examples/` were zero bytes, the training-guides section linked four scripts under `examples/scripts/` (a directory that has never existed), and the contributing link pointed at `CONTRIBUTING.md` while the file is named `CONTRIBUTION.md`.

Adds the three basic examples, all runnable on CPU: a minimal GRPO run against a toy prompt set and a reward you can check by eye, inference from a model or a checkpoint, and evaluation through the `Evaluator`. I ran all three before committing rather than only writing them, which is how the two problems below surfaced.

The README now links the scripts that exist, split by whether they need a GPU, and says plainly that the DPO, PRM and multimodal examples are not written yet. The added test walks every relative link in the README and asserts the target exists and, for Python files, is not empty. It fails on `main`, and it is what caught the `CONTRIBUTING` typo.

Two things worth flagging from running them. The examples pin `dtype=torch.float32` on purpose: several checkpoints, `opt-125m` among them, declare float16 in their config, and the library's AdamW turns fp16 weights to nan in a single step. That is a separate defect and I have not worked around it beyond the examples. Separately, GRPO generation emits transformers' right-padding warning for decoder-only models on every step, which is worth a look on its own.

Stacked on the evaluation PR, since `evaluate_model.py` uses `Evaluator`.
