### PR TITLE
Document the vLLM worker and drop the unsupported 80% figure from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,20 @@ ThinkRL is built on a high-performance stack designed for scale:
 ### Core Components
 
 **vLLM - High-Throughput Inference**
-RLHF depends heavily on generation speed. ThinkRL uses [vLLM](https://github.com/vllm-project/vllm) for **80% faster experience collection**, leveraging PagedAttention and continuous batching.
+RLHF depends heavily on generation speed, so ThinkRL can offload rollout generation to
+[vLLM](https://github.com/vllm-project/vllm) and its PagedAttention and continuous batching.
+
+This runs out of process: `thinkrl/integration/vllm_worker.py` is a standalone FastAPI
+server holding the vLLM engine, and the trainers talk to it through
+`thinkrl/integration/vllm_client.py`, pushing updated weights over NCCL between rollouts.
+Pass `use_vllm=True` to `GRPOTrainer` or `ReinforcePPTrainer` to use it. See
+[the vLLM worker guide](./docs/vllm_worker.md) for how to start one, and read the security
+note there before exposing it: the worker binds every interface by default and has no
+authentication.
+
+The in-process `thinkrl.generation` engine is not implemented yet, and the "80% faster"
+figure that used to sit here was never accompanied by a benchmark in this repository, so it
+has been removed rather than restated.
 
 **DeepSpeed - Memory-Efficient Training**
 Native integration with [DeepSpeed](https://github.com/microsoft/DeepSpeed) (ZeRO-2/3) enables training **70B+ parameter** models on commodity hardware.

--- a/docs/vllm_worker.md
+++ b/docs/vllm_worker.md
@@ -1,0 +1,70 @@
+# vLLM worker
+
+ThinkRL offloads rollout generation to vLLM through a standalone server rather than an
+in-process engine. `thinkrl/generation/vllm_engine.py` is an empty placeholder; the working
+path is the worker plus client described here.
+
+## Shape
+
+- `thinkrl/integration/vllm_worker.py` holds the vLLM engine behind a FastAPI server.
+- `thinkrl/integration/vllm_client.py` is what the trainers use: it submits prompts and
+  pushes updated policy weights to the worker over NCCL between rollouts.
+- `GRPOTrainer` and `ReinforcePPTrainer` take `use_vllm=True` and `vllm_group_port`.
+
+Keeping the engine out of process means the training job and the generation job do not
+compete for the same CUDA context, and weights move over NCCL rather than through a
+serialization round trip.
+
+## Starting a worker
+
+```bash
+python -m thinkrl.integration.vllm_worker \
+    --model HuggingFaceTB/SmolLM2-135M \
+    --host 127.0.0.1 \
+    --port 8000 \
+    --group-port 51216
+```
+
+Then point a trainer at it:
+
+```python
+trainer = GRPOTrainer(
+    model=model,
+    ref_model=ref_model,
+    tokenizer=tokenizer,
+    dataset=dataset,
+    reward_fn=reward_fn,
+    use_vllm=True,
+    vllm_group_port=51216,
+)
+```
+
+## Endpoints
+
+| Route | Method | Purpose |
+|---|---|---|
+| `/health` | GET | Liveness check; the client polls this before submitting work |
+| `/generate` | POST | Generate completions for a batch of prompts |
+| `/update_weights` | POST | Pull updated policy weights over the NCCL group |
+| `/metrics` | GET | Engine counters |
+| `/shutdown` | POST | Terminate the worker |
+
+## Security
+
+**The worker has no authentication, and `--host` defaults to `0.0.0.0`,** which binds every
+interface. `/shutdown` and `/update_weights` are both unauthenticated, so anyone who can
+reach the port can stop your run or replace the weights the policy generates from.
+
+Bind it to loopback (`--host 127.0.0.1`) unless the training process is on another machine,
+and when it must be reachable, put it behind a firewall rule that admits only the training
+host. Do not expose it to a shared network or the internet.
+
+## Requirements
+
+vLLM is an optional dependency and is not installed by default:
+
+```bash
+pip install vllm
+```
+
+It needs a CUDA GPU. There is no macOS build, so the worker cannot be run on Apple silicon.


### PR DESCRIPTION
Closes #109.

The README made in-library vLLM generation a headline claim, "80% faster experience collection", while `thinkrl/generation/vllm_engine.py` is zero bytes. What exists is the out-of-process worker plus client under `thinkrl/integration/`, functional but undocumented anywhere outside its own source, so a reader following the claim had nothing to follow and `--use_vllm` resolved to nothing.

Taking the issue's first option: the worker is the real architecture, so this documents it. The README section now names the two modules and the `use_vllm` flag and links a new `docs/vllm_worker.md` covering how to start a worker, the five routes, the optional `vllm` dependency and its CUDA requirement. I verified the routes against the source rather than the module docstring.

The security note is prominent rather than buried: `--host` defaults to `0.0.0.0` and neither `/shutdown` nor `/update_weights` is authenticated, so anyone who can reach the port can stop a run or replace the weights it generates from. That is #85 and is not fixed here, but users should not meet it unwarned.

I removed the 80% figure rather than restating it, since there is no benchmark in the repository behind it. Happy to put it back with a number attached if one exists.

One thing I found while checking the routes and did not touch: `VLLMClient.check_weights` posts to `/check_weights`, and the worker defines no such route, so that method always fails. It wants its own issue.

Deleting the empty `thinkrl/generation/` package is the other half of the issue's suggestion and I left it alone, since whether an in-process engine is still planned is your call.
