### PR TITLE
Refuse to build an Adam optimizer over float16 weights

### DIFF
--- a/tests/test_training/test_fp16_optimizer_guard.py
+++ b/tests/test_training/test_fp16_optimizer_guard.py
@@ -1,0 +1,81 @@
+"""Regression test: float16 weights must not be handed to an Adam-family optimizer.
+
+Adam keeps its moments in the parameter dtype. In float16 the second moment underflows and
+eps=1e-8 is exactly 0.0, so one step turns every weight into nan while the reported loss
+stays finite. The failure only surfaces later, as `probability tensor contains inf, nan`
+out of generate().
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from thinkrl.algorithms.grpo import GRPOAlgorithm
+from thinkrl.training.mixed_precision import check_optimizable_dtype
+
+
+class _TinyLM(nn.Module):
+    def __init__(self, vocab: int = 16, dim: int = 8):
+        super().__init__()
+        self.emb = nn.Embedding(vocab, dim)
+        self.head = nn.Linear(dim, vocab)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        return {"logits": self.head(self.emb(input_ids))}
+
+
+def test_the_underlying_failure_is_real():
+    """Pins the mechanism the guard exists for, independent of any ThinkRL code."""
+    param = nn.Parameter(torch.randn(4, 4, dtype=torch.float16))
+    param.grad = torch.full_like(param, 1e-3)
+
+    torch.optim.AdamW([param], lr=1e-6, eps=1e-8).step()
+
+    assert not torch.isfinite(param).all(), "float16 AdamW no longer breaks; the guard can go"
+    assert float(torch.tensor(1e-8, dtype=torch.float16)) == 0.0
+
+
+def test_float32_and_bfloat16_pass():
+    for dtype in (torch.float32, torch.bfloat16):
+        check_optimizable_dtype(_TinyLM().to(dtype))
+
+
+def test_float16_is_rejected():
+    with pytest.raises(ValueError, match="float16"):
+        check_optimizable_dtype(_TinyLM().half())
+
+
+def test_the_error_says_how_to_fix_it():
+    with pytest.raises(ValueError) as excinfo:
+        check_optimizable_dtype(_TinyLM().half())
+
+    message = str(excinfo.value)
+    assert "float32 or bfloat16" in message
+    assert "0.0 in float16" in message
+    assert "nan" in message
+
+
+def test_frozen_float16_parameters_are_ignored():
+    """A frozen fp16 reference model is fine; the optimizer never touches it."""
+    model = _TinyLM().half()
+    for param in model.parameters():
+        param.requires_grad = False
+
+    check_optimizable_dtype(model)
+
+
+def test_algorithm_construction_rejects_a_float16_policy():
+    with pytest.raises(ValueError, match="float16"):
+        GRPOAlgorithm(policy_model=_TinyLM().half())
+
+
+def test_algorithm_construction_accepts_float32():
+    assert GRPOAlgorithm(policy_model=_TinyLM()) is not None
+
+
+def test_a_caller_supplied_optimizer_is_left_alone():
+    """The guard covers the optimizer the library builds, not one the caller brought."""
+    model = _TinyLM().half()
+    optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
+
+    assert GRPOAlgorithm(policy_model=model, optimizer=optimizer) is not None

--- a/thinkrl/algorithms/base.py
+++ b/thinkrl/algorithms/base.py
@@ -25,6 +25,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.optim import Optimizer
 
+from thinkrl.training.mixed_precision import check_optimizable_dtype
 from thinkrl.utils.logging import get_logger
 from thinkrl.utils.metrics import (
     MetricsTracker,
@@ -130,6 +131,10 @@ class BaseRLHFAlgorithm(ABC):
 
         # Optimizer
         if optimizer is None:
+            # An Adam-family optimizer cannot update float16 weights in place: eps
+            # underflows to zero and the first step produces nan while the loss still
+            # looks finite. Fail here rather than after the damage.
+            check_optimizable_dtype(policy_model)
             self.optimizer = torch.optim.AdamW(policy_model.parameters(), lr=learning_rate)
         else:
             self.optimizer = optimizer

--- a/thinkrl/training/mixed_precision.py
+++ b/thinkrl/training/mixed_precision.py
@@ -329,6 +329,47 @@ class MixedPrecisionTrainer:
             self.scaler.load_state_dict(state["scaler"])
 
 
+def check_optimizable_dtype(model: nn.Module, optimizer_eps: float = 1e-8) -> None:
+    """Raise if the model's parameters cannot survive an optimizer step in their own dtype.
+
+    Adam-family optimizers keep their moment estimates in the parameter dtype. In float16
+    the second moment underflows toward zero for ordinary gradients, and the usual
+    ``eps=1e-8`` is not representable at all: the nearest float16 value is 0.0, so the
+    update divides by zero and every parameter becomes inf or nan.
+
+    This is silent when it happens. The loss stays finite and the step is reported as
+    successful, because the damage lands in the weights after the loss is computed. A
+    float16 checkpoint therefore trains for exactly one step and then generates from a nan
+    model, surfacing as a `probability tensor contains inf, nan` error from ``generate``
+    rather than as an optimizer problem.
+
+    bfloat16 is unaffected: it carries float32's exponent range, so eps is representable
+    and the moments do not underflow.
+
+    Args:
+        model: Model whose parameters the optimizer will update
+        optimizer_eps: The eps the optimizer is configured with
+
+    Raises:
+        ValueError: If any trainable parameter is float16
+    """
+    fp16_params = [name for name, param in model.named_parameters() if param.requires_grad and param.dtype == torch.float16]
+    if not fp16_params:
+        return
+
+    representable = float(torch.tensor(optimizer_eps, dtype=torch.float16))
+    raise ValueError(
+        f"{len(fp16_params)} parameters are float16 (first: {fp16_params[0]}), which an "
+        f"Adam-family optimizer cannot update in place: eps={optimizer_eps} is {representable} "
+        "in float16, so the update divides by zero and the weights become nan after a single "
+        "step, while the loss still looks finite.\n"
+        "Load the model in float32 or bfloat16 (`from_pretrained(..., dtype=torch.float32)`), "
+        "or pass your own optimizer with float32 master weights. Note that many checkpoints, "
+        "including facebook/opt-125m, declare float16 in their config and load that way by "
+        "default."
+    )
+
+
 def get_autocast_dtype(precision: str) -> torch.dtype:
     """Get autocast dtype for a precision string."""
     dtype_map = {
@@ -365,6 +406,7 @@ __all__ = [
     "PrecisionType",
     "MixedPrecisionConfig",
     "MixedPrecisionTrainer",
+    "check_optimizable_dtype",
     "get_autocast_dtype",
     "cast_model_to_dtype",
     "enable_tf32",

--- a/thinkrl/training/sft_trainer.py
+++ b/thinkrl/training/sft_trainer.py
@@ -21,6 +21,7 @@ import torch
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from thinkrl.training.mixed_precision import check_optimizable_dtype
 from thinkrl.utils.logging import get_logger
 
 
@@ -368,6 +369,7 @@ class SFTTrainer:
             self.model_engine = self.model
 
             # Restore manual optimizer/scheduler setup for non-DeepSpeed
+            check_optimizable_dtype(self.model)
             self.optimizer = torch.optim.AdamW(
                 self.model.parameters(),
                 lr=self.args.learning_rate,


### PR DESCRIPTION
Closes #113.

Training any float16 checkpoint destroys the model on the first optimizer step, silently. Adam keeps its moment estimates in the parameter dtype; in float16 the second moment underflows toward zero and `eps=1e-8` is not representable at all, the nearest float16 value being `0.0`, so the update divides by zero.

`check_optimizable_dtype` raises at optimizer construction with the dtype, the offending parameter and the two ways out. It is called at both places the library builds an optimizer, `algorithms/base.py:133` and `training/sft_trainer.py:371`. bfloat16 passes, since it carries float32's exponent range. Frozen float16 parameters pass, since the optimizer never touches them, so an fp16 reference model is still fine. A caller-supplied optimizer is left alone, on the grounds that someone passing their own has made a choice.

Proper mixed precision with float32 master weights is the real fix and is much larger. This is the guard for the meantime: a run that silently produces a NaN model should not be reachable.

Eight tests. The first one pins the underlying failure with no ThinkRL code involved, so if a future torch makes fp16 AdamW safe the test says so and the guard can be removed rather than lingering.
