### PR TITLE
Add the /check_weights route the vLLM client already calls

### DIFF
--- a/tests/test_integration/test_vllm_client_worker_contract.py
+++ b/tests/test_integration/test_vllm_client_worker_contract.py
@@ -1,0 +1,45 @@
+"""Regression test: every endpoint the vLLM client calls must exist on the worker.
+
+`VLLMClient.check_weights` posted to `/check_weights`, which the worker never defined, so
+every REINFORCE++ run with `use_vllm=True` died at trainer setup with a 404. The two files
+cannot be imported without vllm and uvicorn installed, so the contract is checked against
+the sources, which is also what makes the test runnable in CI without a GPU.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+PACKAGE = Path(__file__).resolve().parents[2] / "thinkrl" / "integration"
+CLIENT = (PACKAGE / "vllm_client.py").read_text()
+WORKER = (PACKAGE / "vllm_worker.py").read_text()
+
+# f"{self.url}/health" and friends
+REQUESTED = sorted(set(re.findall(r'\{self\.url\}(/[a-z_]+)"', CLIENT)))
+REGISTERED = sorted(set(re.findall(r'@app\.(?:get|post)\("(/[a-z_]+)"\)', WORKER)))
+
+
+def test_the_sources_were_actually_parsed():
+    assert REQUESTED, "no client requests found; the extraction pattern has drifted"
+    assert REGISTERED, "no worker routes found; the extraction pattern has drifted"
+
+
+@pytest.mark.parametrize("path", REQUESTED)
+def test_every_requested_path_is_registered(path):
+    assert path in REGISTERED, f"vllm_client.py posts to {path}, which vllm_worker.py does not define"
+
+
+def test_check_weights_specifically_is_registered():
+    """The endpoint this test file exists for."""
+    assert "/check_weights" in REGISTERED
+
+
+def test_check_weights_returns_the_shape_the_client_parses():
+    """The client reads result['status'] and result['details']."""
+    route = WORKER[WORKER.index('@app.post("/check_weights")') : WORKER.index('@app.post("/update_weights")')]
+
+    assert '"status": "ok"' in route
+    assert '"status": "mismatch"' in route
+    assert '"details"' in route

--- a/thinkrl/integration/vllm_worker.py
+++ b/thinkrl/integration/vllm_worker.py
@@ -258,6 +258,42 @@ def create_app(args: argparse.Namespace) -> FastAPI:
             "log_probs": log_probs_list,
         })
 
+    @app.post("/check_weights")
+    async def check_weights(request: Request):
+        """
+        Compare the trainer's parameter shapes against the loaded model.
+
+        The client calls this before the first weight sync so that a structural mismatch is
+        reported here, rather than as a confusing NCCL failure or a silently wrong policy
+        once weights start moving. The response shape is what VLLMClient.check_weights
+        already parses: {"status": "ok"} or {"status": "mismatch", "details": [...]}.
+        """
+        if not hasattr(app.state, "engine") or app.state.engine is None:
+            return JSONResponse({"error": "engine not initialized"}, status_code=503)
+
+        body = await request.json()
+        expected = body.get("params") or {}
+
+        model = _get_vllm_model(app.state.engine)
+        actual = {name: list(param.shape) for name, param in model.named_parameters()}
+
+        details = []
+        for name, shape in expected.items():
+            if name not in actual:
+                details.append(f"{name}: missing on the worker")
+            elif list(actual[name]) != list(shape):
+                details.append(f"{name}: trainer has {list(shape)}, worker has {list(actual[name])}")
+
+        for name in actual:
+            if name not in expected:
+                details.append(f"{name}: present on the worker, absent on the trainer")
+
+        if details:
+            logger.warning(f"Model structure mismatch, {len(details)} differences")
+            return JSONResponse({"status": "mismatch", "details": details[:20]})
+
+        return JSONResponse({"status": "ok"})
+
     @app.post("/update_weights")
     async def update_weights():
         """


### PR DESCRIPTION
Closes #114.

`VLLMClient.check_weights` posted to `/check_weights` and the worker defined no such route, so `raise_for_status()` turned it into a 404 and every REINFORCE++ run with `use_vllm=True` died at trainer setup, before the first rollout. `GRPOTrainer` does not call it, which is why only one of the two vLLM paths was affected.

I added the server half rather than removing the client method, since the check is worth having: it turns a structural mismatch into a clear message up front instead of a confusing NCCL failure or a silently wrong policy once weights start moving.

The route compares the posted `{name: shape}` mapping against the loaded model and returns `{"status": "ok"}` or `{"status": "mismatch", "details": [...]}`, which is the shape the client already parses. It reports missing, extra and differently-shaped parameters, capped at twenty differences so a wholly mismatched model does not return an unreadable payload.

The added test asserts every path the client requests is registered by the worker. It works on the sources rather than by importing them, since neither file imports without `vllm` and `uvicorn` present; that also lets it run in CI without a GPU. It fails on `main`.

I have no GPU, so the route is not exercised against a live vLLM engine. The parameter-shape comparison is straightforward, but a second pair of eyes on the `_get_vllm_model` call would be welcome, since that helper already carries version-dependent fallbacks.
