### PR TITLE
Left-pad rollout batches so short prompts are not generated from pad tokens

### DIFF
--- a/tests/test_training/test_rollout_padding_side.py
+++ b/tests/test_training/test_rollout_padding_side.py
@@ -1,0 +1,89 @@
+"""Regression test: rollout batches must be left-padded.
+
+These prompts go straight into model.generate. A decoder-only model continues from the last
+position, so right padding makes every prompt shorter than the batch maximum continue from
+pad tokens, and the reward function then scores completions the policy never produces.
+"""
+
+import inspect
+
+import torch
+from transformers import GPT2Config, GPT2LMHeadModel
+
+import thinkrl.training.grpo_trainer as grpo_trainer
+import thinkrl.training.reinforce_pp_trainer as reinforce_pp_trainer
+from thinkrl.data.loaders import create_rlhf_collate_fn
+
+
+class _StubTokenizer:
+    pad_token_id = 0
+    padding_side = "right"  # the library default, and the thing being overridden
+
+
+def _batch():
+    return [
+        {"input_ids": torch.tensor([5, 6, 7]), "attention_mask": torch.tensor([1, 1, 1])},
+        {"input_ids": torch.tensor([8]), "attention_mask": torch.tensor([1])},
+    ]
+
+
+def test_collator_left_pads_when_asked():
+    collated = create_rlhf_collate_fn(_StubTokenizer(), padding_side="left")(_batch())
+
+    # The short sequence keeps its real token last, where generation continues from.
+    assert collated["input_ids"][1].tolist() == [0, 0, 8]
+    assert collated["attention_mask"][1].tolist() == [0, 0, 1]
+
+
+def test_collator_still_right_pads_by_default():
+    """Loss computation wants right padding, so the default must not move."""
+    collated = create_rlhf_collate_fn(_StubTokenizer())(_batch())
+
+    assert collated["input_ids"][1].tolist() == [8, 0, 0]
+
+
+def test_both_rollout_trainers_request_left_padding():
+    for module in (grpo_trainer, reinforce_pp_trainer):
+        source = inspect.getsource(module)
+        assert 'padding_side="left"' in source, f"{module.__name__} builds its rollout loader without left padding"
+
+
+def test_left_padding_makes_batched_generation_match_unbatched():
+    """The property that actually matters, checked on a real generate() call."""
+    torch.manual_seed(0)
+    model = GPT2LMHeadModel(GPT2Config(n_layer=2, n_head=2, n_embd=16, n_positions=32, vocab_size=40)).eval()
+
+    long_prompt = torch.tensor([5, 6, 7, 8])
+    short_prompt = torch.tensor([9])
+
+    def generate(input_ids, attention_mask):
+        out = model.generate(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            max_new_tokens=5,
+            do_sample=False,
+            pad_token_id=0,
+        )
+        return out[:, input_ids.shape[1] :]
+
+    alone = generate(short_prompt.unsqueeze(0), torch.ones(1, 1, dtype=torch.long))
+
+    collate = create_rlhf_collate_fn(_StubTokenizer(), padding_side="left")
+    left = collate(
+        [
+            {"input_ids": long_prompt, "attention_mask": torch.ones(4, dtype=torch.long)},
+            {"input_ids": short_prompt, "attention_mask": torch.ones(1, dtype=torch.long)},
+        ]
+    )
+    batched_left = generate(left["input_ids"], left["attention_mask"])
+
+    right = create_rlhf_collate_fn(_StubTokenizer())(
+        [
+            {"input_ids": long_prompt, "attention_mask": torch.ones(4, dtype=torch.long)},
+            {"input_ids": short_prompt, "attention_mask": torch.ones(1, dtype=torch.long)},
+        ]
+    )
+    batched_right = generate(right["input_ids"], right["attention_mask"])
+
+    assert torch.equal(batched_left[1], alone[0]), "left-padded batch diverged from unbatched generation"
+    assert not torch.equal(batched_right[1], alone[0]), "right padding no longer diverges; the fix can go"

--- a/thinkrl/training/grpo_trainer.py
+++ b/thinkrl/training/grpo_trainer.py
@@ -125,12 +125,18 @@ class GRPOTrainer:
             logger.info("Using VLLM for generation.")
 
         # Create DataLoader
+        # Rollout batches are padded on the left. These prompts go straight into
+        # model.generate, and a decoder-only model continues from the last position, so
+        # right padding would make every prompt shorter than the batch maximum continue
+        # from pad tokens. The completions scored by the reward function would then be
+        # ones the policy never produces at inference.
         dataloader = RLHFDataLoader(
             dataset=self.dataset,
             tokenizer=self.tokenizer,
             batch_size=batch_size,
             shuffle=True,
             drop_last=False,
+            padding_side="left",
         )
 
         step = 0

--- a/thinkrl/training/reinforce_pp_trainer.py
+++ b/thinkrl/training/reinforce_pp_trainer.py
@@ -127,12 +127,18 @@ class ReinforcePPTrainer:
             logger.info("Using VLLM for generation.")
 
         # Create DataLoader using RLHFDataLoader from loaders.py
+        # Rollout batches are padded on the left. These prompts go straight into
+        # model.generate, and a decoder-only model continues from the last position, so
+        # right padding would make every prompt shorter than the batch maximum continue
+        # from pad tokens. The completions scored by the reward function would then be
+        # ones the policy never produces at inference.
         dataloader = RLHFDataLoader(
             dataset=self.dataset,
             tokenizer=self.tokenizer,
             batch_size=batch_size,
             shuffle=True,
             drop_last=False,
+            padding_side="left",
         )
 
         step = 0


### PR DESCRIPTION
Closes #115.

The rollout collator took its padding side from the tokenizer, and `get_tokenizer` defaults to `"right"`, so every prompt shorter than the batch maximum continued from pad tokens instead of from its own last real token. transformers warned about it on every step.

The cost is specific to RL rather than cosmetic. The corrupted text is what the reward function scores, so the advantage is computed for a completion the policy would never produce at inference, and the update moves the policy toward it. With group sampling one short prompt corrupts its whole group together, so the group-relative baseline is uniformly wrong rather than noisy, and the damage scales with how uneven the prompt lengths are, which is worst on exactly the mixed-length reasoning datasets the library targets.

Reproduced on `facebook/opt-125m` with greedy decoding: batched right-padded generation matched unbatched output on 1 of 2 prompts, left-padded matched on 2 of 2. The prompt that diverged echoed itself instead of answering.

Only the two rollout loaders change. The collator default stays `"right"`, which is correct for the loss path, where left padding would misalign the labels; `create_rlhf_collate_fn` already accepted an explicit side, so nothing else moves.

Four tests, one of which drives a real `generate()` call and asserts the batched and unbatched outputs agree. It also asserts right padding still diverges, so if that ever stops being true the test says so rather than passing vacuously.
