### PR TITLE
Implement thinkrl train, and stop the algorithm name being dropped on parse

### DIFF
--- a/tests/test_cli/test_train_command.py
+++ b/tests/test_cli/test_train_command.py
@@ -1,0 +1,105 @@
+"""`thinkrl train` builds a trainer from a config instead of printing and exiting 0."""
+
+import inspect
+
+import pytest
+import yaml
+
+typer = pytest.importorskip("typer")
+from typer.testing import CliRunner  # noqa: E402
+
+from thinkrl.cli.main import TRAINABLE_FROM_CONFIG, _resolve_algorithm_name, app  # noqa: E402
+from thinkrl.config.base import ThinkRLConfig  # noqa: E402
+
+
+runner = CliRunner()
+
+
+def _config_dict(algorithm="grpo", dataset="/tmp/does-not-exist.jsonl"):
+    return {
+        "model": {"name_or_path": "facebook/opt-125m", "use_flash_attention": False},
+        "algorithm": {"name": algorithm, "learning_rate": 1e-6, "group_size": 2},
+        "data": {"dataset": dataset, "max_prompt_length": 32, "max_response_length": 32},
+        "distributed": {"micro_batch_size": 2, "bf16": False},
+        "logging": {"output_dir": "/tmp/thinkrl-test-out"},
+    }
+
+
+def _write(tmp_path, data):
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(data))
+    return str(path)
+
+
+def test_train_is_no_longer_a_stub():
+    """The regression: the body ended at `# TODO: Implement actual training loop`."""
+    source = inspect.getsource(app.registered_commands[0].callback)
+
+    assert "TODO: Implement actual training loop" not in source
+
+
+def test_algorithm_name_survives_parsing():
+    """No algorithm config declares a `name` field, so it used to be dropped on parse."""
+    config = ThinkRLConfig.from_dict(_config_dict())
+
+    assert type(config.algorithm).__name__ == "GRPOConfig"
+    assert config.algorithm.name == "grpo"
+
+
+def test_algorithm_name_survives_a_round_trip():
+    """to_dict/from_dict silently turned every algorithm back into the ppo default."""
+    original = ThinkRLConfig.from_dict(_config_dict(algorithm="dapo"))
+    restored = ThinkRLConfig.from_dict(original.to_dict())
+
+    assert restored.algorithm.name == "dapo"
+    assert type(restored.algorithm).__name__ == "DAPOConfig"
+
+
+def test_resolve_algorithm_name_reads_both_shapes():
+    parsed = ThinkRLConfig.from_dict(_config_dict())
+    assert _resolve_algorithm_name(parsed) == "grpo"
+
+    fallback = ThinkRLConfig.from_dict({"algorithm": {"name": "not-an-algorithm"}})
+    assert _resolve_algorithm_name(fallback) == "not-an-algorithm"
+
+
+def test_unsupported_algorithm_fails_by_name(tmp_path):
+    config = _write(tmp_path, _config_dict(algorithm="dpo"))
+
+    result = runner.invoke(app, ["train", "--config", config])
+
+    assert result.exit_code != 0
+    combined = result.stdout + (result.stderr or "")
+    assert "dpo" in combined
+    assert "grpo" in combined, "the error should name what is supported"
+
+
+def test_missing_dataset_is_rejected_before_loading_a_model(tmp_path):
+    data = _config_dict()
+    data["data"]["dataset"] = None
+    config = _write(tmp_path, data)
+
+    result = runner.invoke(app, ["train", "--config", config])
+
+    assert result.exit_code != 0
+    assert "dataset" in result.stdout + (result.stderr or "")
+
+
+def test_dry_run_still_validates_without_training(tmp_path):
+    result = runner.invoke(app, ["train", "--config", _write(tmp_path, _config_dict()), "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Configuration is valid" in result.stdout
+
+
+def test_resume_is_rejected_rather_than_silently_ignored(tmp_path):
+    result = runner.invoke(
+        app, ["train", "--config", _write(tmp_path, _config_dict()), "--resume", str(tmp_path)]
+    )
+
+    assert result.exit_code != 0
+    assert "resume" in (result.stdout + (result.stderr or "")).lower()
+
+
+def test_supported_set_is_not_empty():
+    assert TRAINABLE_FROM_CONFIG

--- a/tests/test_training/test_rl_trainer_checkpointing.py
+++ b/tests/test_training/test_rl_trainer_checkpointing.py
@@ -1,0 +1,79 @@
+"""Regression test: the RL trainers must persist progress, not only the final model."""
+
+import inspect
+
+import torch
+import torch.nn as nn
+
+import thinkrl.training.grpo_trainer as grpo_trainer
+import thinkrl.training.reinforce_pp_trainer as reinforce_pp_trainer
+import thinkrl.training.star_trainer as star_trainer
+from thinkrl.utils.checkpoint import CheckpointManager, save_training_checkpoint
+
+
+class _TinyLM(nn.Module):
+    def __init__(self, vocab: int = 16, dim: int = 8):
+        super().__init__()
+        self.emb = nn.Embedding(vocab, dim)
+        self.head = nn.Linear(dim, vocab)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        return {"logits": self.head(self.emb(input_ids))}
+
+
+TRAINERS = (grpo_trainer.GRPOTrainer, reinforce_pp_trainer.ReinforcePPTrainer, star_trainer.STaRTrainer)
+
+
+def test_every_rl_trainer_accepts_a_checkpoint_directory():
+    """The regression: none of these took a checkpoint argument at all."""
+    for trainer in TRAINERS:
+        params = inspect.signature(trainer.train).parameters
+        assert "checkpoint_dir" in params, f"{trainer.__name__}.train has no checkpoint_dir"
+        assert "save_every" in params, f"{trainer.__name__}.train has no save_every"
+
+
+def test_every_rl_trainer_reaches_the_checkpoint_manager():
+    for module in (grpo_trainer, reinforce_pp_trainer, star_trainer):
+        source = inspect.getsource(module)
+        assert "CheckpointManager" in source, f"{module.__name__} never constructs a CheckpointManager"
+        assert "save_training_checkpoint" in source, f"{module.__name__} never saves"
+
+
+def test_helper_is_a_no_op_without_a_manager():
+    assert save_training_checkpoint(None, model=_TinyLM(), step=1) is None
+
+
+def test_helper_writes_a_loadable_checkpoint(tmp_path):
+    manager = CheckpointManager(tmp_path, max_checkpoints=5)
+    model = _TinyLM()
+
+    path = save_training_checkpoint(manager, model=model, epoch=0, step=7, metrics={"loss": 1.5})
+
+    assert path is not None and path.exists()
+    assert manager.checkpoints, "checkpoint was not registered with the manager"
+
+
+def test_helper_coerces_tensor_metrics(tmp_path):
+    """Trainers collect metrics as a mix of floats and 0-dim tensors."""
+    manager = CheckpointManager(tmp_path, max_checkpoints=5)
+
+    path = save_training_checkpoint(
+        manager,
+        model=_TinyLM(),
+        step=1,
+        metrics={"loss": torch.tensor(0.5), "reward": 2.0, "grad": torch.ones(3), "name": "ignored"},
+    )
+
+    assert path is not None
+    saved = manager.checkpoints[-1]["metrics"]
+    assert saved == {"loss": 0.5, "reward": 2.0}
+
+
+def test_rotation_keeps_max_checkpoints(tmp_path):
+    manager = CheckpointManager(tmp_path, max_checkpoints=2)
+    model = _TinyLM()
+
+    for step in range(4):
+        save_training_checkpoint(manager, model=model, step=step)
+
+    assert len(manager.checkpoints) <= 2

--- a/thinkrl/cli/main.py
+++ b/thinkrl/cli/main.py
@@ -43,6 +43,139 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+# Algorithms `thinkrl train` can drive today. The rest are registered but have no trainer
+# wired to a configuration, so naming them explicitly is better than a generic failure.
+TRAINABLE_FROM_CONFIG = {"grpo"}
+
+
+def _resolve_algorithm_name(cfg) -> str:
+    algorithm = cfg.algorithm
+    if algorithm is None:
+        raise ValueError("config has no `algorithm` section, so there is nothing to train")
+    name = algorithm.get("name") if isinstance(algorithm, dict) else getattr(algorithm, "name", None)
+    if not name:
+        raise ValueError("config `algorithm` section has no `name`")
+    return str(name).lower()
+
+
+def _algorithm_field(cfg, field: str, default):
+    algorithm = cfg.algorithm
+    if isinstance(algorithm, dict):
+        return algorithm.get(field, default)
+    return getattr(algorithm, field, default)
+
+
+def _run_training(cfg, resume=None) -> None:
+    """Build a trainer from a configuration and run it.
+
+    Kept deliberately narrow: only algorithms with a trainer that takes a config are
+    accepted, and anything else fails by name rather than doing nothing.
+    """
+    if resume:
+        # Checked before anything expensive is loaded: refusing after a model download
+        # would waste minutes to report a flag we could reject immediately.
+        typer.echo(f"Error: --resume is not implemented for `train` yet (got {resume}).", err=True)
+        typer.echo("       See https://github.com/ellanorai/ThinkRL/issues/103", err=True)
+        raise typer.Exit(code=1)
+
+    name = _resolve_algorithm_name(cfg)
+    if name not in TRAINABLE_FROM_CONFIG:
+        supported = ", ".join(sorted(TRAINABLE_FROM_CONFIG))
+        typer.echo(
+            f"Error: `thinkrl train` cannot drive `{name}` from a config yet. "
+            f"Supported: {supported}.",
+            err=True,
+        )
+        typer.echo(
+            "       Use the dedicated CLI if one exists (`thinkrl grpo`, `thinkrl star`), "
+            "or see https://github.com/ellanorai/ThinkRL/issues/118",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    import torch
+    from transformers import AutoTokenizer
+
+    from thinkrl.algorithms.grpo import GRPOConfig
+    from thinkrl.data.datasets import RLHFDataset
+    from thinkrl.models.loader import get_model
+    from thinkrl.training.grpo_trainer import GRPOTrainer
+
+    if not cfg.data.dataset:
+        typer.echo("Error: config `data.dataset` is required to train.", err=True)
+        raise typer.Exit(code=1)
+
+    ref_name = cfg.model.ref_model_name_or_path or cfg.model.name_or_path
+
+    typer.echo("Loading tokenizer and models...")
+    tokenizer = AutoTokenizer.from_pretrained(
+        cfg.model.name_or_path,
+        padding_side="left",
+        trust_remote_code=cfg.model.trust_remote_code,
+    )
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    model_kwargs = dict(
+        bf16=cfg.distributed.bf16,
+        fp16=cfg.distributed.fp16,
+        trust_remote_code=cfg.model.trust_remote_code,
+        use_flash_attention=cfg.model.use_flash_attention,
+    )
+    policy_model = get_model(cfg.model.name_or_path, model_type="actor", **model_kwargs)
+    ref_model = get_model(ref_name, model_type="ref", **model_kwargs)
+
+    if cfg.model.gradient_checkpointing and hasattr(policy_model, "gradient_checkpointing_enable"):
+        policy_model.gradient_checkpointing_enable()
+
+    typer.echo(f"Loading dataset: {cfg.data.dataset}")
+    dataset = RLHFDataset(
+        dataset_name_or_path=cfg.data.dataset,
+        tokenizer=tokenizer,
+        split=cfg.data.dataset_split,
+        prompt_column=cfg.data.prompt_column,
+        max_length=cfg.data.max_length,
+    )
+
+    def reward_fn(prompts, completions, **kwargs):
+        """Placeholder reward until the config carries one.
+
+        Length-based, so it is obviously a placeholder rather than something that looks
+        trained. `data.reward_fn` is not part of the schema yet.
+        """
+        return torch.tensor([float(len(c)) for c in completions])
+
+    typer.echo("Warning: no reward function in the config schema yet; using a length-based placeholder.")
+
+    trainer = GRPOTrainer(
+        model=policy_model,
+        ref_model=ref_model,
+        tokenizer=tokenizer,
+        dataset=dataset,
+        reward_fn=reward_fn,
+        config=GRPOConfig(
+            learning_rate=_algorithm_field(cfg, "learning_rate", 1e-6),
+            group_size=_algorithm_field(cfg, "group_size", 64),
+            beta=_algorithm_field(cfg, "beta", 0.04),
+            n_epochs=_algorithm_field(cfg, "n_epochs", 1),
+        ),
+    )
+
+    batch_size = cfg.distributed.micro_batch_size
+    steps = max(1, len(dataset) // max(1, batch_size))
+    typer.echo(f"Training for {steps} steps at batch size {batch_size}...")
+
+    trainer.train(
+        steps=steps,
+        batch_size=batch_size,
+        checkpoint_dir=cfg.logging.output_dir,
+        save_every=cfg.logging.save_every_n_steps,
+        max_checkpoints=cfg.logging.save_total_limit,
+    )
+
+    typer.echo(f"Training complete. Checkpoints in {cfg.logging.output_dir}")
+
+
 def _check_typer():
     """Check if typer is available."""
     if not TYPER_AVAILABLE:
@@ -112,8 +245,7 @@ if TYPER_AVAILABLE:
         typer.echo(f"Model: {cfg.model.name_or_path}")
         typer.echo(f"Strategy: {cfg.distributed.strategy}")
 
-        # TODO: Implement actual training loop
-        typer.echo("\nNote: Training implementation pending")
+        _run_training(cfg, resume=resume)
 
     @app.command()
     def generate(

--- a/thinkrl/config/base.py
+++ b/thinkrl/config/base.py
@@ -254,6 +254,12 @@ class ThinkRLConfig:
                 # Let's instantiate
                 algorithm = ConfigClass(**filtered_args)
 
+                # No algorithm config declares a `name` field, so the resolved name is lost
+                # unless it is carried on the instance. Without it `cfg.algorithm.name`
+                # raises AttributeError, and to_dict/from_dict silently round-trips every
+                # algorithm back to the "ppo" default.
+                algorithm.name = algo_name
+
             except Exception as e:
                 logger.warning(f"Failed to load algorithm config for '{algo_name}': {e}. Falling back to dict.")
                 algorithm = algo_data
@@ -288,8 +294,12 @@ class ThinkRLConfig:
         elif isinstance(self.algorithm, dict):
             algo_dict = self.algorithm
         else:
-            # It's a dataclass, use asdict
+            # It's a dataclass, use asdict. `name` is carried on the instance rather than
+            # declared as a field, so asdict drops it and it has to be put back.
             algo_dict = asdict(self.algorithm)
+            name = getattr(self.algorithm, "name", None)
+            if name is not None:
+                algo_dict["name"] = name
 
         result = {
             "model": asdict(self.model),

--- a/thinkrl/training/grpo_trainer.py
+++ b/thinkrl/training/grpo_trainer.py
@@ -9,6 +9,7 @@ from thinkrl.algorithms.grpo import GRPOAlgorithm, GRPOConfig
 from thinkrl.data.datasets import RLHFDataset
 from thinkrl.data.loaders import RLHFDataLoader
 from thinkrl.integration.vllm_client import VLLMClient
+from thinkrl.utils.checkpoint import CheckpointManager, save_training_checkpoint
 from thinkrl.utils.logging import get_logger
 
 
@@ -100,10 +101,30 @@ class GRPOTrainer:
             self.vllm_client = VLLMClient(group_port=vllm_group_port)
             self.vllm_client.init_weight_sync(self.device)
 
-    def train(self, steps: int = 1000, batch_size: int = 4, log_interval: int = 10):
+    def train(
+        self,
+        steps: int = 1000,
+        batch_size: int = 4,
+        log_interval: int = 10,
+        checkpoint_dir: str | None = None,
+        save_every: int = 0,
+        max_checkpoints: int = 5,
+    ):
         """
         Main training loop.
+
+        Args:
+            steps: Number of optimisation steps to run.
+            batch_size: Prompts per rollout.
+            log_interval: Steps between log lines.
+            checkpoint_dir: Where to write checkpoints. Nothing is written without it.
+            save_every: Save every N steps; 0 disables periodic saves. A final checkpoint is
+                still written whenever checkpoint_dir is set.
+            max_checkpoints: How many checkpoints to keep before the oldest rotates out.
         """
+        checkpointer = (
+            CheckpointManager(checkpoint_dir, max_checkpoints=max_checkpoints) if checkpoint_dir else None
+        )
         try:
             from tqdm import tqdm
         except ImportError:
@@ -135,8 +156,19 @@ class GRPOTrainer:
 
         step = 0
         epoch = 0
+        step_metrics: dict[str, Any] = {}
 
         progress_bar = tqdm(total=steps, desc="Training")
+
+        def checkpoint():
+            return save_training_checkpoint(
+                checkpointer,
+                model=self.algorithm.policy_model,
+                optimizer=getattr(self.algorithm, "optimizer", None),
+                epoch=epoch,
+                step=step,
+                metrics=step_metrics,
+            )
 
         while step < steps:
             for batch_prompts in dataloader:
@@ -215,9 +247,13 @@ class GRPOTrainer:
                 progress_bar.update(1)
                 step += 1
 
+                if save_every and step % save_every == 0:
+                    checkpoint()
+
             epoch += 1
 
         progress_bar.close()
+        checkpoint()
 
     def make_experience(self, batch_prompts: dict[str, Any]) -> dict[str, torch.Tensor]:
         """

--- a/thinkrl/training/reinforce_pp_trainer.py
+++ b/thinkrl/training/reinforce_pp_trainer.py
@@ -9,6 +9,7 @@ from thinkrl.algorithms.reinforce_pp import REINFORCEPPAlgorithm, REINFORCEPPCon
 from thinkrl.data.datasets import RLHFDataset
 from thinkrl.data.loaders import RLHFDataLoader
 from thinkrl.integration.vllm_client import VLLMClient
+from thinkrl.utils.checkpoint import CheckpointManager, save_training_checkpoint
 from thinkrl.utils.logging import get_logger
 
 
@@ -101,10 +102,30 @@ class ReinforcePPTrainer:
             # Verify compatibility before starting
             self.vllm_client.check_weights(self.algorithm.policy_model)
 
-    def train(self, steps: int = 1000, batch_size: int = 4, log_interval: int = 10):
+    def train(
+        self,
+        steps: int = 1000,
+        batch_size: int = 4,
+        log_interval: int = 10,
+        checkpoint_dir: str | None = None,
+        save_every: int = 0,
+        max_checkpoints: int = 5,
+    ):
         """
         Main training loop.
+
+        Args:
+            steps: Number of optimisation steps to run.
+            batch_size: Prompts per rollout.
+            log_interval: Steps between log lines.
+            checkpoint_dir: Where to write checkpoints. Nothing is written without it.
+            save_every: Save every N steps; 0 disables periodic saves. A final checkpoint is
+                still written whenever checkpoint_dir is set.
+            max_checkpoints: How many checkpoints to keep before the oldest rotates out.
         """
+        checkpointer = (
+            CheckpointManager(checkpoint_dir, max_checkpoints=max_checkpoints) if checkpoint_dir else None
+        )
         try:
             from tqdm import tqdm
         except ImportError:
@@ -137,8 +158,19 @@ class ReinforcePPTrainer:
 
         step = 0
         epoch = 0
+        step_metrics: dict[str, Any] = {}
 
         progress_bar = tqdm(total=steps, desc="Training")
+
+        def checkpoint():
+            return save_training_checkpoint(
+                checkpointer,
+                model=self.algorithm.policy_model,
+                optimizer=getattr(self.algorithm, "optimizer", None),
+                epoch=epoch,
+                step=step,
+                metrics=step_metrics,
+            )
 
         while step < steps:
             for batch_prompts in dataloader:
@@ -220,9 +252,13 @@ class ReinforcePPTrainer:
                 progress_bar.update(1)
                 step += 1
 
+                if save_every and step % save_every == 0:
+                    checkpoint()
+
             epoch += 1
 
         progress_bar.close()
+        checkpoint()
 
     def make_experience(self, batch_prompts: dict[str, Any]) -> dict[str, torch.Tensor]:
         """

--- a/thinkrl/training/star_trainer.py
+++ b/thinkrl/training/star_trainer.py
@@ -9,6 +9,7 @@ from transformers import GenerationConfig, PreTrainedTokenizer
 from thinkrl.algorithms.star import STaRAlgorithm, STaRConfig
 from thinkrl.data.datasets import RLHFDataset
 from thinkrl.data.loaders import RLHFDataLoader
+from thinkrl.utils.checkpoint import CheckpointManager, save_training_checkpoint
 from thinkrl.utils.logging import get_logger
 
 
@@ -61,11 +62,27 @@ class STaRTrainer:
         self.algorithm = STaRAlgorithm(policy_model=model, optimizer=optimizer, config=self.config, **algo_kwargs)
         self.algorithm.to(self.device)
 
-    def train(self, iterations: int | None = None):
+    def train(
+        self,
+        iterations: int | None = None,
+        checkpoint_dir: str | None = None,
+        save_every: int = 1,
+        max_checkpoints: int = 5,
+    ):
         """
         Main STaR loop.
+
+        Args:
+            iterations: Number of STaR iterations; defaults to config.max_iterations.
+            checkpoint_dir: Where to write checkpoints. Nothing is written without it.
+            save_every: Save every N iterations; 0 disables periodic saves. A final
+                checkpoint is still written whenever checkpoint_dir is set.
+            max_checkpoints: How many checkpoints to keep before the oldest rotates out.
         """
         iterations = iterations or self.config.max_iterations
+        checkpointer = (
+            CheckpointManager(checkpoint_dir, max_checkpoints=max_checkpoints) if checkpoint_dir else None
+        )
 
         logger.info(f"Starting STaR training for {iterations} iterations...")
 
@@ -85,6 +102,11 @@ class STaRTrainer:
 
             # 5. Fine-tune on collected data
             self.fine_tune(collected_data, iter_idx)
+
+            if save_every and (iter_idx + 1) % save_every == 0:
+                save_training_checkpoint(checkpointer, model=self.model, epoch=iter_idx, step=iter_idx + 1)
+
+        save_training_checkpoint(checkpointer, model=self.model, epoch=iterations - 1, step=iterations)
 
     def collect_successful_rationales(self, iter_idx: int):
         """

--- a/thinkrl/utils/checkpoint.py
+++ b/thinkrl/utils/checkpoint.py
@@ -765,10 +765,50 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
     return config
 
 
+def save_training_checkpoint(
+    manager: CheckpointManager | None,
+    model: nn.Module,
+    optimizer: Optimizer | None = None,
+    scheduler: _LRScheduler | None = None,
+    epoch: int | None = None,
+    step: int | None = None,
+    metrics: dict[str, Any] | None = None,
+) -> Path | None:
+    """Save a training checkpoint, tolerating a missing manager and tensor-valued metrics.
+
+    Trainers collect metrics as a mix of floats and zero-dimensional tensors, while
+    CheckpointManager stores them in JSON metadata, so they are coerced here rather than at
+    every call site.
+
+    Returns the checkpoint path, or None when no manager is configured.
+    """
+    if manager is None:
+        return None
+
+    scalar_metrics = {}
+    for key, value in (metrics or {}).items():
+        if isinstance(value, torch.Tensor):
+            if value.numel() != 1:
+                continue
+            value = value.item()
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            scalar_metrics[key] = float(value)
+
+    return manager.save_checkpoint(
+        model=model,
+        optimizer=optimizer,
+        scheduler=scheduler,
+        epoch=epoch,
+        step=step,
+        metrics=scalar_metrics,
+    )
+
+
 # Public API
 __all__ = [
     "CheckpointManager",
     "save_checkpoint",
+    "save_training_checkpoint",
     "load_checkpoint",
     "save_config",
     "load_config",


### PR DESCRIPTION
Closes #118. Also closes #120.

`train` loaded a config, validated it, printed three lines and exited 0 at `# TODO: Implement actual training loop`. Since `train` and `info` are the only two places in the package that construct a `ThinkRLConfig`, and `info` only prints it, nothing consumed a configuration at all. That is the reason the fields in #102 are dead and the reason the files in #106 have no reader.

It now builds tokenizer, models, dataset and algorithm from the config and runs `GRPOTrainer`, passing the logging section's `output_dir`, `save_every_n_steps` and `save_total_limit` through to checkpointing, which takes two entries off the unhonoured list in #102. Verified end to end on `facebook/opt-125m`: one step, finite loss, two checkpoints on disk.

Two deliberate refusals rather than silence. An algorithm with no config-driven trainer fails naming itself and what is supported, and `--resume` exits non-zero pointing at #103 before any model is loaded, since refusing after a download would waste minutes to report a flag we can reject immediately.

A prerequisite defect had to be fixed first, which is #120: `from_dict` resolves the algorithm name, filters it out because no algorithm config declares a `name` field, and drops it. So `cfg.algorithm.name` raised `AttributeError` for every valid config and `train` crashed at line 243 before reaching any of the new code, and `to_dict`/`from_dict` silently round-tripped every algorithm back to the PPO default. The name is now carried on the instance and re-emitted by `to_dict`. Happy to split that into its own PR if you would rather review it separately.

Two things I left: the reward function is still a length-based placeholder with a warning, because the config schema has no field for one, and `TRAINABLE_FROM_CONFIG` is just `{"grpo"}` for now since it is the only trainer that takes a config cleanly. Both are additive from here.

Stacked on the checkpointing PR, since `train` passes the checkpoint arguments through.
