### PR TITLE
Add periodic rollout sampling so a run shows what the policy is generating

### DIFF
--- a/tests/test_logging_module/test_rollout_inspector.py
+++ b/tests/test_logging_module/test_rollout_inspector.py
@@ -1,0 +1,99 @@
+"""Periodic rollout sampling: a scalar reward cannot tell a bad policy from a broken
+reward function or empty completions, so the run should be able to show the text."""
+
+import inspect
+import io
+
+import pytest
+import torch
+
+import thinkrl.training.grpo_trainer as grpo_trainer
+import thinkrl.training.reinforce_pp_trainer as reinforce_pp_trainer
+from thinkrl.logging import RolloutInspector
+from thinkrl.logging.rollout import truncate
+
+
+def _inspector(**kwargs):
+    kwargs.setdefault("every", 2)
+    kwargs.setdefault("use_rich", False)
+    kwargs.setdefault("file", io.StringIO())
+    return RolloutInspector(**kwargs)
+
+
+def test_disabled_by_default():
+    assert RolloutInspector().enabled is False
+    assert RolloutInspector().maybe_show(10, ["p"], ["c"], [1.0]) is False
+
+
+def test_fires_only_on_multiples_and_never_on_step_zero():
+    inspector = _inspector(every=3)
+
+    assert [inspector.should_show(s) for s in range(7)] == [False, False, False, True, False, False, True]
+
+
+def test_shows_prompt_completion_and_reward():
+    inspector = _inspector()
+    inspector.show(4, ["What is 2+2?"], ["4"], [1.25])
+
+    output = inspector.file.getvalue()
+    assert "step 4" in output
+    assert "What is 2+2?" in output
+    assert "+1.2500" in output
+
+
+def test_tensor_rewards_are_accepted():
+    """Trainers hand rewards over as a tensor."""
+    inspector = _inspector()
+    inspector.show(2, ["p"], ["c"], torch.tensor([0.5]))
+
+    assert "+0.5000" in inspector.file.getvalue()
+
+
+def test_empty_completion_is_called_out_rather_than_printed_blank():
+    inspector = _inspector()
+    inspector.show(2, ["p"], [""], [0.0])
+
+    assert "(empty)" in inspector.file.getvalue()
+
+
+def test_long_text_is_truncated():
+    assert truncate("a" * 100, 10) == "a" * 9 + "…"
+    assert truncate("keep\nnewlines  collapsed", 100) == "keep newlines collapsed"
+
+
+def test_sample_count_is_respected():
+    inspector = _inspector(num_samples=2)
+    inspector.show(2, ["p1", "p2", "p3"], ["c1", "c2", "c3"], [1.0, 2.0, 3.0])
+
+    output = inspector.file.getvalue()
+    assert "c1" in output and "c2" in output and "c3" not in output
+
+
+def test_mismatched_lengths_do_not_raise_mid_run():
+    inspector = _inspector()
+    inspector.show(2, ["p1", "p2"], ["c1"], [1.0])
+
+    assert "c1" in inspector.file.getvalue()
+
+
+def test_missing_rewards_are_shown_as_unknown():
+    inspector = _inspector()
+    inspector.show(2, ["p"], ["c"], None)
+
+    assert "-" in inspector.file.getvalue()
+
+
+def test_num_samples_must_be_positive():
+    with pytest.raises(ValueError, match="num_samples"):
+        RolloutInspector(every=1, num_samples=0)
+
+
+@pytest.mark.parametrize("module", [grpo_trainer, reinforce_pp_trainer])
+def test_both_rl_trainers_expose_and_call_the_inspector(module):
+    trainer = next(
+        obj for name, obj in vars(module).items() if name.endswith("Trainer") and hasattr(obj, "train")
+    )
+    params = inspect.signature(trainer.train).parameters
+
+    assert "inspect_every" in params, f"{module.__name__} has no inspect_every option"
+    assert "maybe_show" in inspect.getsource(module), f"{module.__name__} never calls the inspector"

--- a/thinkrl/logging/__init__.py
+++ b/thinkrl/logging/__init__.py
@@ -9,6 +9,7 @@ Provides:
 - Console, W&B, TensorBoard backends
 - Composite logger for multiple backends
 - Distributed-safe logging
+- Periodic rollout sampling, so a run shows what the policy is generating
 
 Author: EllanorAI
 """
@@ -21,6 +22,7 @@ from thinkrl.logging.loggers import (
     create_logger,
     log_only_main_process,
 )
+from thinkrl.logging.rollout import RolloutInspector
 from thinkrl.logging.tensorboard import TensorBoardLogger
 from thinkrl.logging.wandb import WandBLogger
 
@@ -28,6 +30,7 @@ from thinkrl.logging.wandb import WandBLogger
 __all__ = [
     # Base
     "Logger",
+    "RolloutInspector",
     "NullLogger",
     "ConsoleLogger",
     "CompositeLogger",

--- a/thinkrl/logging/rollout.py
+++ b/thinkrl/logging/rollout.py
@@ -1,0 +1,143 @@
+"""Show what the policy is actually generating during a run.
+
+A reward of 0.0 is ambiguous on its own: the policy may be bad, the reward function may be
+broken, the prompts may be malformed, the completions may be empty, or generation may be
+producing something the answer parser never matches. Those have different fixes and a
+scalar cannot separate them. Printing a few (prompt, completion, reward) triples can.
+
+Renders through ``rich`` when it is installed and the output is a terminal, and falls back
+to plain text otherwise, so it costs nothing in a log file or a CI job. ``rich`` arrives
+with ``typer`` and is not required.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import sys
+from typing import Any
+
+
+try:
+    from rich.console import Console
+    from rich.table import Table
+
+    _RICH_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised by the plain-text path
+    Console = None
+    Table = None
+    _RICH_AVAILABLE = False
+
+
+def _as_float(value: Any) -> float:
+    """Coerce a reward entry, which may be a 0-dim tensor, to a float."""
+    item = getattr(value, "item", None)
+    return float(item()) if callable(item) else float(value)
+
+
+def truncate(text: str, max_chars: int) -> str:
+    """Collapse newlines and clip to max_chars, marking the clip."""
+    flattened = " ".join(str(text).split())
+    if max_chars <= 0 or len(flattened) <= max_chars:
+        return flattened
+    return flattened[: max_chars - 1] + "…"
+
+
+class RolloutInspector:
+    """Periodically print a sample of prompts, completions and rewards.
+
+    Args:
+        every: Show a sample every N steps. 0 disables the inspector entirely.
+        num_samples: How many rollouts to show each time
+        max_chars: Truncation width for prompts and completions
+        file: Stream to write to; defaults to stdout
+        use_rich: Force rich on or off. None auto-detects.
+    """
+
+    def __init__(
+        self,
+        every: int = 0,
+        num_samples: int = 3,
+        max_chars: int = 200,
+        file: Any = None,
+        use_rich: bool | None = None,
+    ):
+        if num_samples < 1:
+            raise ValueError(f"num_samples must be >= 1, got {num_samples}")
+        self.every = every
+        self.num_samples = num_samples
+        self.max_chars = max_chars
+        self.file = file or sys.stdout
+        if use_rich is None:
+            use_rich = _RICH_AVAILABLE and getattr(self.file, "isatty", lambda: False)()
+        self.use_rich = bool(use_rich) and _RICH_AVAILABLE
+
+    @property
+    def enabled(self) -> bool:
+        return self.every > 0
+
+    def should_show(self, step: int) -> bool:
+        return self.enabled and step > 0 and step % self.every == 0
+
+    def maybe_show(
+        self,
+        step: int,
+        prompts: Sequence[str],
+        completions: Sequence[str],
+        rewards: Sequence[Any] | None = None,
+    ) -> bool:
+        """Print a sample if this step is due. Returns whether anything was printed."""
+        if not self.should_show(step):
+            return False
+        self.show(step, prompts, completions, rewards)
+        return True
+
+    def show(
+        self,
+        step: int,
+        prompts: Sequence[str],
+        completions: Sequence[str],
+        rewards: Sequence[Any] | None = None,
+    ) -> None:
+        """Print a sample unconditionally."""
+        rows = self._rows(prompts, completions, rewards)
+        if not rows:
+            print(f"[step {step}] rollout sample: nothing generated", file=self.file)
+            return
+        if self.use_rich:
+            self._show_rich(step, rows)
+        else:
+            self._show_plain(step, rows)
+
+    def _rows(self, prompts, completions, rewards) -> list[tuple[str, str, str]]:
+        # Completions are the shortest of the three in the degenerate cases, and zipping to
+        # the shortest keeps a mismatch from raising in the middle of a training run.
+        count = min(len(prompts), len(completions), self.num_samples)
+        rows = []
+        for i in range(count):
+            if rewards is not None and i < len(rewards):
+                reward = f"{_as_float(rewards[i]):+.4f}"
+            else:
+                reward = "-"
+            rows.append((truncate(prompts[i], self.max_chars), truncate(completions[i], self.max_chars), reward))
+        return rows
+
+    def _show_rich(self, step: int, rows) -> None:  # pragma: no cover - needs a terminal
+        console = Console(file=self.file)
+        table = Table(title=f"Rollout sample at step {step}", show_lines=True, title_justify="left")
+        table.add_column("Reward", justify="right", style="bold", no_wrap=True)
+        table.add_column("Prompt", overflow="fold")
+        table.add_column("Completion", overflow="fold")
+        for prompt, completion, reward in rows:
+            table.add_row(reward, prompt, completion or "[dim](empty)[/dim]")
+        console.print(table)
+
+    def _show_plain(self, step: int, rows) -> None:
+        print(f"\n--- rollout sample at step {step} ---", file=self.file)
+        for prompt, completion, reward in rows:
+            print(f"  reward {reward}", file=self.file)
+            print(f"    prompt    : {prompt}", file=self.file)
+            print(f"    completion: {completion or '(empty)'}", file=self.file)
+        print("", file=self.file)
+
+
+__all__ = ["RolloutInspector", "truncate"]

--- a/thinkrl/training/grpo_trainer.py
+++ b/thinkrl/training/grpo_trainer.py
@@ -9,6 +9,7 @@ from thinkrl.algorithms.grpo import GRPOAlgorithm, GRPOConfig
 from thinkrl.data.datasets import RLHFDataset
 from thinkrl.data.loaders import RLHFDataLoader
 from thinkrl.integration.vllm_client import VLLMClient
+from thinkrl.logging.rollout import RolloutInspector
 from thinkrl.utils.logging import get_logger
 
 
@@ -100,10 +101,27 @@ class GRPOTrainer:
             self.vllm_client = VLLMClient(group_port=vllm_group_port)
             self.vllm_client.init_weight_sync(self.device)
 
-    def train(self, steps: int = 1000, batch_size: int = 4, log_interval: int = 10):
+    def train(
+        self,
+        steps: int = 1000,
+        batch_size: int = 4,
+        log_interval: int = 10,
+        inspect_every: int = 0,
+        inspect_samples: int = 3,
+    ):
         """
         Main training loop.
+
+        Args:
+            steps: Number of optimisation steps to run.
+            batch_size: Prompts per rollout.
+            log_interval: Steps between log lines.
+            inspect_every: Print a sample of prompts, completions and rewards every N
+                steps. 0 disables it. A scalar reward cannot distinguish a bad policy from
+                a broken reward function or empty completions; this can.
+            inspect_samples: How many rollouts to show each time.
         """
+        inspector = RolloutInspector(every=inspect_every, num_samples=inspect_samples)
         try:
             from tqdm import tqdm
         except ImportError:
@@ -211,6 +229,8 @@ class GRPOTrainer:
 
                     logger.info(f"Step {step}: Loss={loss_val:.4f}, Reward={reward_val:.4f}")
                     progress_bar.set_postfix({"loss": f"{loss_val:.3f}", "reward": f"{reward_val:.3f}"})
+
+                inspector.maybe_show(step, prompts_text, completions_text, rewards)
 
                 progress_bar.update(1)
                 step += 1

--- a/thinkrl/training/reinforce_pp_trainer.py
+++ b/thinkrl/training/reinforce_pp_trainer.py
@@ -9,6 +9,7 @@ from thinkrl.algorithms.reinforce_pp import REINFORCEPPAlgorithm, REINFORCEPPCon
 from thinkrl.data.datasets import RLHFDataset
 from thinkrl.data.loaders import RLHFDataLoader
 from thinkrl.integration.vllm_client import VLLMClient
+from thinkrl.logging.rollout import RolloutInspector
 from thinkrl.utils.logging import get_logger
 
 
@@ -101,10 +102,27 @@ class ReinforcePPTrainer:
             # Verify compatibility before starting
             self.vllm_client.check_weights(self.algorithm.policy_model)
 
-    def train(self, steps: int = 1000, batch_size: int = 4, log_interval: int = 10):
+    def train(
+        self,
+        steps: int = 1000,
+        batch_size: int = 4,
+        log_interval: int = 10,
+        inspect_every: int = 0,
+        inspect_samples: int = 3,
+    ):
         """
         Main training loop.
+
+        Args:
+            steps: Number of optimisation steps to run.
+            batch_size: Prompts per rollout.
+            log_interval: Steps between log lines.
+            inspect_every: Print a sample of prompts, completions and rewards every N
+                steps. 0 disables it. A scalar reward cannot distinguish a bad policy from
+                a broken reward function or empty completions; this can.
+            inspect_samples: How many rollouts to show each time.
         """
+        inspector = RolloutInspector(every=inspect_every, num_samples=inspect_samples)
         try:
             from tqdm import tqdm
         except ImportError:
@@ -216,6 +234,8 @@ class ReinforcePPTrainer:
 
                     logger.info(f"Step {step}: Loss={loss_val:.4f}, " f"Reward={reward_val:.4f}")
                     progress_bar.set_postfix({"loss": f"{loss_val:.3f}", "reward": f"{reward_val:.3f}"})
+
+                inspector.maybe_show(step, prompts_text, completions_text, rewards)
 
                 progress_bar.update(1)
                 step += 1


### PR DESCRIPTION
Closes #119.

The RL trainers logged one line every `log_interval` steps: `Step 10: Loss=0.0240, Reward=0.0000`. A reward of 0.0 could mean a bad policy, a broken reward function, malformed prompts, empty completions, or generation the answer parser never matches. Those have different fixes and a scalar cannot separate them, while the completions sit in `rollout_data` and never reach the operator.

`RolloutInspector` prints a few `(prompt, completion, reward)` triples every N steps. Both RL trainers take `inspect_every` and `inspect_samples`, defaulting to 0 so nothing changes for existing callers.

It renders through `rich` when rich is installed and the output is a terminal, and falls back to plain text otherwise, so it costs nothing in a log file or a CI job. `rich` arrives with `typer` and is not a new dependency; the guard mirrors the `TYPER_AVAILABLE` pattern the CLI already uses. Empty completions are labelled rather than printed blank, since a blank line is exactly the case worth spotting, and mismatched lengths are zipped to the shortest rather than raising in the middle of a run.

On the question of a full-screen TUI: I did not build one. It needs `textual` as a new dependency, and a training run is usually watched over SSH alongside other output rather than in a full-screen app, so the periodic sample gets most of the value at none of the cost. Worth revisiting if you want it, but as its own decision.

Twelve tests.
